### PR TITLE
chore: Regenerated main.json file

### DIFF
--- a/infra/main.json
+++ b/infra/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.37.4.10188",
-      "templateHash": "9357865314194843382"
+      "version": "0.40.2.10011",
+      "templateHash": "12309139534707486785"
     }
   },
   "parameters": {
@@ -253,6 +253,7 @@
     },
     "replicaLocation": "[variables('replicaRegionPairs')[parameters('location')]]",
     "allTags": "[union(createObject('azd-env-name', parameters('solutionName')), parameters('tags'))]",
+    "existingTags": "[coalesce(resourceGroup().tags, createObject())]",
     "deployerPrincipalType": "[if(contains(deployer(), 'userPrincipalName'), 'User', 'ServicePrincipal')]",
     "deployerInfo": "[deployer()]",
     "deployingUserPrincipalId": "[variables('deployerInfo').objectId]",
@@ -372,7 +373,7 @@
       "apiVersion": "2021-04-01",
       "name": "default",
       "properties": {
-        "tags": "[shallowMerge(createArray(resourceGroup().tags, variables('allTags'), createObject('TemplateName', 'Customer Chat bot', 'Type', if(parameters('enablePrivateNetworking'), 'WAF', 'Non-WAF'), 'CreatedBy', parameters('createdBy'), 'DeploymentName', deployment().name)))]"
+        "tags": "[union(variables('existingTags'), variables('allTags'), createObject('TemplateName', 'Customer Chat bot', 'Type', if(parameters('enablePrivateNetworking'), 'WAF', 'Non-WAF'), 'CreatedBy', parameters('createdBy'), 'DeploymentName', deployment().name))]"
       }
     },
     "avmTelemetry": {
@@ -453,7 +454,7 @@
     "logAnalyticsWorkspace": {
       "condition": "[and(parameters('enableMonitoring'), not(variables('useExistingLogAnalytics')))]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2022-09-01",
+      "apiVersion": "2025-04-01",
       "name": "[take(format('avm.res.operational-insights.workspace.{0}', variables('logAnalyticsWorkspaceResourceName')), 64)]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -3559,7 +3560,7 @@
     "applicationInsights": {
       "condition": "[parameters('enableMonitoring')]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2022-09-01",
+      "apiVersion": "2025-04-01",
       "name": "[take(format('avm.res.insights.component.{0}', variables('applicationInsightsResourceName')), 64)]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -4290,7 +4291,7 @@
     "virtualNetwork": {
       "condition": "[parameters('enablePrivateNetworking')]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2022-09-01",
+      "apiVersion": "2025-04-01",
       "name": "[take(format('module.virtualNetwork.{0}', variables('solutionSuffix')), 64)]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -4327,8 +4328,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.37.4.10188",
-              "templateHash": "14758510323771707965"
+              "version": "0.40.2.10011",
+              "templateHash": "8601660412091035417"
             }
           },
           "definitions": {
@@ -4736,7 +4737,7 @@
               },
               "condition": "[not(empty(tryGet(parameters('subnets')[copyIndex()], 'networkSecurityGroup')))]",
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2022-09-01",
+              "apiVersion": "2025-04-01",
               "name": "[take(format('avm.res.network.network-security-group.{0}.{1}', tryGet(parameters('subnets')[copyIndex()], 'networkSecurityGroup', 'name'), parameters('resourceSuffix')), 64)]",
               "properties": {
                 "expressionEvaluationOptions": {
@@ -5388,7 +5389,7 @@
             },
             "virtualNetwork": {
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2022-09-01",
+              "apiVersion": "2025-04-01",
               "name": "[take(format('avm.res.network.virtual-network.{0}', parameters('name')), 64)]",
               "properties": {
                 "expressionEvaluationOptions": {
@@ -7143,7 +7144,7 @@
     "bastionHost": {
       "condition": "[parameters('enablePrivateNetworking')]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2022-09-01",
+      "apiVersion": "2025-04-01",
       "name": "[take(format('avm.res.network.bastion-host.{0}', variables('bastionResourceName')), 64)]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -8472,7 +8473,7 @@
     "maintenanceConfiguration": {
       "condition": "[parameters('enablePrivateNetworking')]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2022-09-01",
+      "apiVersion": "2025-04-01",
       "name": "[take(format('avm.res.compute.virtual-machine.{0}', variables('maintenanceConfigurationResourceName')), 64)]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -8876,7 +8877,7 @@
     "windowsVmDataCollectionRules": {
       "condition": "[and(parameters('enablePrivateNetworking'), parameters('enableMonitoring'))]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2022-09-01",
+      "apiVersion": "2025-04-01",
       "name": "[take(format('avm.res.insights.data-collection-rule.{0}', variables('dataCollectionRulesResourceName')), 64)]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -9850,7 +9851,7 @@
     "proximityPlacementGroup": {
       "condition": "[parameters('enablePrivateNetworking')]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2022-09-01",
+      "apiVersion": "2025-04-01",
       "name": "[take(format('avm.res.compute.proximity-placement-group.{0}', variables('proximityPlacementGroupResourceName')), 64)]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -10207,7 +10208,7 @@
     "virtualMachine": {
       "condition": "[parameters('enablePrivateNetworking')]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2022-09-01",
+      "apiVersion": "2025-04-01",
       "name": "[take(format('avm.res.compute.virtual-machine.{0}', variables('virtualMachineResourceName')), 64)]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -18632,7 +18633,7 @@
       },
       "condition": "[and(parameters('enablePrivateNetworking'), or(not(variables('useExistingAiFoundryAiProject')), not(contains(variables('aiRelatedDnsZoneIndices'), copyIndex()))))]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2022-09-01",
+      "apiVersion": "2025-04-01",
       "name": "[format('avm.res.network.private-dns-zone.{0}', if(contains(variables('privateDnsZones')[copyIndex()], 'azurecontainerapps.io'), 'containerappenv', split(variables('privateDnsZones')[copyIndex()], '.')[1]))]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -21800,7 +21801,7 @@
     "existingAiFoundryAiServicesDeployments": {
       "condition": "[variables('useExistingAiFoundryAiProject')]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2022-09-01",
+      "apiVersion": "2025-04-01",
       "name": "[take(format('module.ai-services-model-deployments.{0}', variables('aiFoundryAiServicesResourceName')), 64)]",
       "subscriptionId": "[variables('aiFoundryAiServicesSubscriptionId')]",
       "resourceGroup": "[variables('aiFoundryAiServicesResourceGroupName')]",
@@ -21851,8 +21852,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.37.4.10188",
-              "templateHash": "10614806341150549004"
+              "version": "0.40.2.10011",
+              "templateHash": "13812472332917536126"
             }
           },
           "definitions": {
@@ -22159,7 +22160,7 @@
               },
               "type": "Microsoft.Authorization/roleAssignments",
               "apiVersion": "2022-04-01",
-              "scope": "[format('Microsoft.CognitiveServices/accounts/{0}', parameters('name'))]",
+              "scope": "[resourceId('Microsoft.CognitiveServices/accounts', parameters('name'))]",
               "name": "[coalesce(tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'name'), guid(resourceId('Microsoft.CognitiveServices/accounts', parameters('name')), coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].principalId, coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].roleDefinitionId))]",
               "properties": {
                 "roleDefinitionId": "[coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].roleDefinitionId]",
@@ -22178,7 +22179,7 @@
     "aiFoundryAiServices": {
       "condition": "[not(variables('useExistingAiFoundryAiProject'))]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2022-09-01",
+      "apiVersion": "2025-04-01",
       "name": "[take(format('avm.res.cognitive-services.account.{0}', variables('aiFoundryAiServicesResourceName')), 64)]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -24802,8 +24803,8 @@
         }
       },
       "dependsOn": [
-        "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').cognitiveServices)]",
         "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').openAI)]",
+        "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').cognitiveServices)]",
         "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').aiServices)]",
         "logAnalyticsWorkspace",
         "virtualNetwork"
@@ -24811,7 +24812,7 @@
     },
     "searchService": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2022-09-01",
+      "apiVersion": "2025-04-01",
       "name": "[take(format('avm.res.search.search-service.{0}', variables('solutionSuffix')), 64)]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -27176,7 +27177,7 @@
     },
     "aiSearchFoundryConnection": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2022-09-01",
+      "apiVersion": "2025-04-01",
       "name": "[take(format('aifp-srch-connection.{0}', variables('solutionSuffix')), 64)]",
       "subscriptionId": "[variables('aiFoundryAiServicesSubscriptionId')]",
       "resourceGroup": "[variables('aiFoundryAiServicesResourceGroupName')]",
@@ -27209,8 +27210,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.37.4.10188",
-              "templateHash": "5794879332811376166"
+              "version": "0.40.2.10011",
+              "templateHash": "15348022841521786626"
             }
           },
           "parameters": {
@@ -27279,7 +27280,7 @@
     "aiFoundryAiServicesProject": {
       "condition": "[not(variables('useExistingAiFoundryAiProject'))]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2022-09-01",
+      "apiVersion": "2025-04-01",
       "name": "[take(format('module.ai-project.{0}', variables('aiFoundryAiProjectResourceName')), 64)]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -27309,8 +27310,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.37.4.10188",
-              "templateHash": "9809540012057219846"
+              "version": "0.40.2.10011",
+              "templateHash": "7507285802464480889"
             }
           },
           "parameters": {
@@ -27402,7 +27403,7 @@
     },
     "cosmosDb": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2022-09-01",
+      "apiVersion": "2025-04-01",
       "name": "[take(format('avm.res.document-db.database-account.{0}', variables('cosmosDbResourceName')), 64)]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -31232,7 +31233,7 @@
     },
     "webServerFarm": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2022-09-01",
+      "apiVersion": "2025-04-01",
       "name": "[take(format('avm.res.web.serverfarm.{0}', variables('webServerFarmResourceName')), 64)]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -31803,7 +31804,7 @@
     },
     "webSiteBackend": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2022-09-01",
+      "apiVersion": "2025-04-01",
       "name": "[take(format('module.web-sites.{0}', variables('backendWebSiteResourceName')), 64)]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -31900,8 +31901,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.37.4.10188",
-              "templateHash": "10197553894229279551"
+              "version": "0.40.2.10011",
+              "templateHash": "15808627380574269133"
             }
           },
           "definitions": {
@@ -32838,7 +32839,7 @@
               },
               "type": "Microsoft.Insights/diagnosticSettings",
               "apiVersion": "2021-05-01-preview",
-              "scope": "[format('Microsoft.Web/sites/{0}', parameters('name'))]",
+              "scope": "[resourceId('Microsoft.Web/sites', parameters('name'))]",
               "name": "[coalesce(tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'name'), format('{0}-diagnosticSettings', parameters('name')))]",
               "properties": {
                 "copy": [
@@ -32878,7 +32879,7 @@
                 "count": "[length(coalesce(parameters('configs'), createArray()))]"
               },
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2022-09-01",
+              "apiVersion": "2025-04-01",
               "name": "[format('{0}-Site-Config-{1}', uniqueString(deployment().name, parameters('location')), copyIndex())]",
               "properties": {
                 "expressionEvaluationOptions": {
@@ -32913,8 +32914,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.37.4.10188",
-                      "templateHash": "16985690110908976374"
+                      "version": "0.40.2.10011",
+                      "templateHash": "2088089358629485989"
                     },
                     "name": "Site App Settings",
                     "description": "This module deploys a Site App Setting."
@@ -33059,7 +33060,7 @@
                 "count": "[length(coalesce(parameters('privateEndpoints'), createArray()))]"
               },
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2022-09-01",
+              "apiVersion": "2025-04-01",
               "name": "[format('{0}-app-PrivateEndpoint-{1}', uniqueString(deployment().name, parameters('location')), copyIndex())]",
               "subscriptionId": "[split(coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'resourceGroupResourceId'), resourceGroup().id), '/')[2]]",
               "resourceGroup": "[split(coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'resourceGroupResourceId'), resourceGroup().id), '/')[4]]",
@@ -33894,7 +33895,7 @@
     "backendToAiProjectUserRole": {
       "condition": "[not(variables('useExistingAiFoundryAiProject'))]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2022-09-01",
+      "apiVersion": "2025-04-01",
       "name": "backend-ai-project-user-role",
       "properties": {
         "expressionEvaluationOptions": {
@@ -33921,8 +33922,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.37.4.10188",
-              "templateHash": "7381695631414898064"
+              "version": "0.40.2.10011",
+              "templateHash": "8575991425594632972"
             }
           },
           "parameters": {
@@ -33977,7 +33978,7 @@
               "condition": "[variables('isProjectScoped')]",
               "type": "Microsoft.Authorization/roleAssignments",
               "apiVersion": "2022-04-01",
-              "scope": "[format('Microsoft.CognitiveServices/accounts/{0}/projects/{1}', variables('parentAccountName'), variables('projectName'))]",
+              "scope": "[resourceId('Microsoft.CognitiveServices/accounts/projects', variables('parentAccountName'), variables('projectName'))]",
               "name": "[variables('uniqueName')]",
               "properties": {
                 "principalId": "[parameters('principalId')]",
@@ -34012,7 +34013,7 @@
     "backendToExistingAiProjectUserRole": {
       "condition": "[variables('useExistingAiFoundryAiProject')]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2022-09-01",
+      "apiVersion": "2025-04-01",
       "name": "backend-existing-ai-project-user",
       "subscriptionId": "[variables('aiFoundryAiServicesSubscriptionId')]",
       "resourceGroup": "[variables('aiFoundryAiServicesResourceGroupName')]",
@@ -34041,8 +34042,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.37.4.10188",
-              "templateHash": "7381695631414898064"
+              "version": "0.40.2.10011",
+              "templateHash": "8575991425594632972"
             }
           },
           "parameters": {
@@ -34097,7 +34098,7 @@
               "condition": "[variables('isProjectScoped')]",
               "type": "Microsoft.Authorization/roleAssignments",
               "apiVersion": "2022-04-01",
-              "scope": "[format('Microsoft.CognitiveServices/accounts/{0}/projects/{1}', variables('parentAccountName'), variables('projectName'))]",
+              "scope": "[resourceId('Microsoft.CognitiveServices/accounts/projects', variables('parentAccountName'), variables('projectName'))]",
               "name": "[variables('uniqueName')]",
               "properties": {
                 "principalId": "[parameters('principalId')]",
@@ -34131,7 +34132,7 @@
     },
     "backendToSearchRole": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2022-09-01",
+      "apiVersion": "2025-04-01",
       "name": "backend-search-contributor-role",
       "properties": {
         "expressionEvaluationOptions": {
@@ -34155,8 +34156,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.37.4.10188",
-              "templateHash": "7381695631414898064"
+              "version": "0.40.2.10011",
+              "templateHash": "8575991425594632972"
             }
           },
           "parameters": {
@@ -34211,7 +34212,7 @@
               "condition": "[variables('isProjectScoped')]",
               "type": "Microsoft.Authorization/roleAssignments",
               "apiVersion": "2022-04-01",
-              "scope": "[format('Microsoft.CognitiveServices/accounts/{0}/projects/{1}', variables('parentAccountName'), variables('projectName'))]",
+              "scope": "[resourceId('Microsoft.CognitiveServices/accounts/projects', variables('parentAccountName'), variables('projectName'))]",
               "name": "[variables('uniqueName')]",
               "properties": {
                 "principalId": "[parameters('principalId')]",
@@ -34246,7 +34247,7 @@
     "searchToExistingAiServicesOpenAIRole": {
       "condition": "[variables('useExistingAiFoundryAiProject')]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2022-09-01",
+      "apiVersion": "2025-04-01",
       "name": "search-existing-aiservices-openai",
       "subscriptionId": "[variables('aiFoundryAiServicesSubscriptionId')]",
       "resourceGroup": "[variables('aiFoundryAiServicesResourceGroupName')]",
@@ -34272,8 +34273,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.37.4.10188",
-              "templateHash": "7381695631414898064"
+              "version": "0.40.2.10011",
+              "templateHash": "8575991425594632972"
             }
           },
           "parameters": {
@@ -34328,7 +34329,7 @@
               "condition": "[variables('isProjectScoped')]",
               "type": "Microsoft.Authorization/roleAssignments",
               "apiVersion": "2022-04-01",
-              "scope": "[format('Microsoft.CognitiveServices/accounts/{0}/projects/{1}', variables('parentAccountName'), variables('projectName'))]",
+              "scope": "[resourceId('Microsoft.CognitiveServices/accounts/projects', variables('parentAccountName'), variables('projectName'))]",
               "name": "[variables('uniqueName')]",
               "properties": {
                 "principalId": "[parameters('principalId')]",
@@ -34363,7 +34364,7 @@
     },
     "webSite": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2022-09-01",
+      "apiVersion": "2025-04-01",
       "name": "[take(format('module.web-sites.{0}', variables('webSiteResourceName')), 64)]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -34422,8 +34423,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.37.4.10188",
-              "templateHash": "10197553894229279551"
+              "version": "0.40.2.10011",
+              "templateHash": "15808627380574269133"
             }
           },
           "definitions": {
@@ -35360,7 +35361,7 @@
               },
               "type": "Microsoft.Insights/diagnosticSettings",
               "apiVersion": "2021-05-01-preview",
-              "scope": "[format('Microsoft.Web/sites/{0}', parameters('name'))]",
+              "scope": "[resourceId('Microsoft.Web/sites', parameters('name'))]",
               "name": "[coalesce(tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'name'), format('{0}-diagnosticSettings', parameters('name')))]",
               "properties": {
                 "copy": [
@@ -35400,7 +35401,7 @@
                 "count": "[length(coalesce(parameters('configs'), createArray()))]"
               },
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2022-09-01",
+              "apiVersion": "2025-04-01",
               "name": "[format('{0}-Site-Config-{1}', uniqueString(deployment().name, parameters('location')), copyIndex())]",
               "properties": {
                 "expressionEvaluationOptions": {
@@ -35435,8 +35436,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.37.4.10188",
-                      "templateHash": "16985690110908976374"
+                      "version": "0.40.2.10011",
+                      "templateHash": "2088089358629485989"
                     },
                     "name": "Site App Settings",
                     "description": "This module deploys a Site App Setting."
@@ -35581,7 +35582,7 @@
                 "count": "[length(coalesce(parameters('privateEndpoints'), createArray()))]"
               },
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2022-09-01",
+              "apiVersion": "2025-04-01",
               "name": "[format('{0}-app-PrivateEndpoint-{1}', uniqueString(deployment().name, parameters('location')), copyIndex())]",
               "subscriptionId": "[split(coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'resourceGroupResourceId'), resourceGroup().id), '/')[2]]",
               "resourceGroup": "[split(coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'resourceGroupResourceId'), resourceGroup().id), '/')[4]]",


### PR DESCRIPTION
This pull request updates the `infra/main.json` infrastructure template with several improvements, primarily focused on upgrading API versions for Azure resource deployments, improving tag management, and updating Bicep template metadata. The changes enhance compatibility with newer Azure features and ensure more robust and maintainable deployments.

**API Version Upgrades:**

* Upgraded `apiVersion` for most `Microsoft.Resources/deployments` resources from `2022-09-01` to `2025-04-01` to leverage the latest Azure capabilities and features. [[1]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L456-R457) [[2]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L3562-R3563) [[3]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L4293-R4294) [[4]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L4739-R4740) [[5]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L5391-R5392) [[6]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L7146-R7147) [[7]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L8475-R8476) [[8]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L8879-R8880) [[9]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L9853-R9854) [[10]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L10210-R10211) [[11]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L18635-R18636) [[12]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L21803-R21804) [[13]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L22181-R22182) [[14]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L24805-R24815) [[15]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L27179-R27180) [[16]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L27282-R27283) [[17]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L27405-R27406) [[18]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L31235-R31236) [[19]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L31806-R31807) [[20]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L32881-R32882)

**Tag and Scope Management Improvements:**

* Improved tag merging for resources by switching from `shallowMerge` to `union` and introducing the `existingTags` variable, ensuring all relevant tags are preserved and applied. [[1]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4R256) [[2]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L375-R376)
* Changed resource `scope` definitions to use `resourceId` instead of string formatting for more reliable resource referencing, especially for role assignments and diagnostic settings. [[1]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L22162-R22163) [[2]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L32841-R32842)

**Bicep Template Metadata Updates:**

* Updated Bicep template generator metadata to version `0.40.2.10011` and refreshed `templateHash` values throughout the file, reflecting the latest template compilation. [[1]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L8-R9) [[2]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L4330-R4332) [[3]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L21854-R21856) [[4]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L27212-R27214) [[5]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L27312-R27314) [[6]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L31903-R31905) [[7]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L32916-R32918)

**Dependency and Ordering Adjustments:**

* Adjusted the order of dependencies in the `dependsOn` array for certain resources to ensure correct deployment sequencing.

These changes collectively modernize the infrastructure template, improve resource tagging and referencing, and ensure compatibility with the latest Azure deployment standards.## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* ...

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->