### PR TITLE
feat: Add PR trigger and coverage comment to test workflow

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -5,7 +5,6 @@ on:
     branches:
       - main
       - dev
-      - demo
     paths:
       - 'src/**/*.py'
       - '.flake8'
@@ -19,7 +18,6 @@ on:
     branches:
       - main
       - dev
-      - demo
     paths:
       - 'src/**/*.py'
       - '.github/workflows/tests.yaml'

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -2,10 +2,32 @@ name: Test Workflow with Coverage
 
 on:
   push:
+    branches:
+      - main
+      - dev
+      - demo
     paths:
       - 'src/**/*.py'
       - '.flake8'
-      - '.github/workflows/pylint.yml'
+      - '.github/workflows/tests.yaml'
+  pull_request:
+    types:
+      - opened
+      - ready_for_review
+      - reopened
+      - synchronize
+    branches:
+      - main
+      - dev
+      - demo
+    paths:
+      - 'src/**/*.py'
+      - '.github/workflows/tests.yaml'
+
+permissions:
+  contents: read
+  actions: read
+  pull-requests: write
 
 jobs:
   backend_tests:
@@ -51,3 +73,14 @@ jobs:
             src/coverage.xml
             src/coverage-junit.xml
             src/htmlcov/
+
+      - name: Pytest Coverage Comment
+        if: |
+          always() &&
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.fork == false
+        uses: MishaKav/pytest-coverage-comment@26f986d2599c288bb62f623d29c2da98609e9cd4  # v1.6.0
+        with:
+          pytest-xml-coverage-path: src/coverage.xml
+          junitxml-path: src/coverage-junit.xml
+          report-only-changed-files: true


### PR DESCRIPTION
## Purpose
This pull request updates the test workflow configuration to improve automation around test coverage reporting and workflow triggers. The changes ensure that tests and coverage comments are run and reported more reliably on relevant branches and pull requests.

**Workflow trigger and permissions updates:**

* The test workflow in `.github/workflows/tests.yaml` is now triggered on pushes and pull requests targeting the `main`, `dev`, and `demo` branches, and only for changes in Python source files or the workflow file itself. This makes test runs more targeted and ensures better coverage of important development branches.
* Workflow permissions have been explicitly set to restrict access, including granting write access to pull requests for coverage commenting.

**Coverage reporting enhancements:**

* Added a step to the workflow using the `MishaKav/pytest-coverage-comment` GitHub Action. On pull requests from non-forks, this step posts a coverage summary as a comment, focusing on files changed in the PR. This helps reviewers quickly see coverage impact without leaving GitHub.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

