### PR TITLE
fix: voice feature issue fix

### DIFF
--- a/src/App/src/App.tsx
+++ b/src/App/src/App.tsx
@@ -186,7 +186,9 @@ function App() {
 
   // Chat functions
   const handleVoiceMessage = async (text: string, role: 'user' | 'assistant') => {
-    let sessionId = currentSessionId;
+    // Use localStorage fallback to avoid race where React state hasn't
+    // propagated the newly created session ID yet.
+    let sessionId = currentSessionId || getCurrentSessionId();
 
     // Create a chat session on the first voice message so the prompt is
     // stored under a real session key and the welcome screen is replaced.
@@ -202,6 +204,12 @@ function App() {
       }
     }
 
+    // Guard: if sessionId is still null (e.g. assistant message arrived
+    // before session was created), skip to avoid writing to ['chat', null].
+    if (!sessionId) {
+      return;
+    }
+
     const msg: ChatMessage = {
       id: `voice-${role}-${Date.now()}`,
       content: text,
@@ -212,9 +220,7 @@ function App() {
     if (role === 'assistant') {
       setIsTyping(false);
     }
-    if (sessionId) {
-      saveVoiceMessage(sessionId, text, role);
-    }
+    saveVoiceMessage(sessionId, text, role);
   };
 
   const handleSendMessage = async (content: string) => {

--- a/src/App/src/App.tsx
+++ b/src/App/src/App.tsx
@@ -185,19 +185,35 @@ function App() {
 
 
   // Chat functions
-  const handleVoiceMessage = (text: string, role: 'user' | 'assistant') => {
+  const handleVoiceMessage = async (text: string, role: 'user' | 'assistant') => {
+    let sessionId = currentSessionId;
+
+    // Create a chat session on the first voice message so the prompt is
+    // stored under a real session key and the welcome screen is replaced.
+    if (!sessionId && role === 'user') {
+      try {
+        const sessionData = await createNewChatSession();
+        sessionId = sessionData.session_id;
+        setCurrentSessionId(sessionId);
+        saveCurrentSessionId(sessionId);
+      } catch {
+        toast.error('Failed to start chat session');
+        return;
+      }
+    }
+
     const msg: ChatMessage = {
       id: `voice-${role}-${Date.now()}`,
       content: text,
       sender: role,
       timestamp: createTimestamp()
     };
-    queryClient.setQueryData(['chat', currentSessionId], (old: ChatMessage[] = []) => [...old, msg]);
+    queryClient.setQueryData(['chat', sessionId], (old: ChatMessage[] = []) => [...old, msg]);
     if (role === 'assistant') {
       setIsTyping(false);
     }
-    if (currentSessionId) {
-      saveVoiceMessage(currentSessionId, text, role);
+    if (sessionId) {
+      saveVoiceMessage(sessionId, text, role);
     }
   };
 

--- a/src/App/src/components/EnhancedChatPanel.tsx
+++ b/src/App/src/components/EnhancedChatPanel.tsx
@@ -64,6 +64,12 @@ export const EnhancedChatPanel = ({
   const audioBufferQueueRef = useRef<string[]>([]);
   const sessionReadyRef = useRef(false);
   const isSpeakingRef = useRef(false);
+  const awaitingResponseRef = useRef(false);
+  const responseTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Tracks whether the current voice turn has already posted the structured tool
+  // result to chat history (via the early `tool_result` event). When true, the
+  // final RESPONSE_DONE transcript skips re-posting to avoid duplicates.
+  const voiceStructuredPostedRef = useRef(false);
 
   isTypingRef.current = isTyping;
   isLoadingRef.current = isLoading;
@@ -307,7 +313,12 @@ export const EnhancedChatPanel = ({
   const stopVoiceSession = async () => {
     setIsVoiceTransitioning(true);
     sessionReadyRef.current = false;
+    awaitingResponseRef.current = false;
     audioBufferQueueRef.current = [];
+    if (responseTimeoutRef.current) {
+      clearTimeout(responseTimeoutRef.current);
+      responseTimeoutRef.current = null;
+    }
 
     const ws = wsRef.current;
     wsRef.current = null;
@@ -488,9 +499,27 @@ export const EnhancedChatPanel = ({
           setVoiceSessionState('thinking');
           setInputValue('');
           lastSentTranscriptRef.current = transcript;
+          awaitingResponseRef.current = true;
 
           // Display user transcript in chat
           onVoiceMessageRef.current?.(transcript, 'user');
+
+          // Timeout: if no assistant response within 30s, show error
+          if (responseTimeoutRef.current) clearTimeout(responseTimeoutRef.current);
+          responseTimeoutRef.current = setTimeout(() => {
+            if (awaitingResponseRef.current) {
+              awaitingResponseRef.current = false;
+              setVoiceError('No response received. Please try again.');
+              setStreamingVoiceText('');
+              setVoiceSessionState('idle');
+              const ws = wsRef.current;
+              wsRef.current = null;
+              if (ws && ws.readyState === WebSocket.OPEN) {
+                ws.send(JSON.stringify({ type: 'stop_session' }));
+                ws.close();
+              }
+            }
+          }, 30_000);
 
           // Auto-stop mic after question captured — prevents feedback
           stopMicrophoneCapture().then(() => setIsVoiceActive(false));
@@ -502,16 +531,41 @@ export const EnhancedChatPanel = ({
           playAssistantAudioChunk(message.data, message.sampleRate || 24000);
         }
 
+        // Tool result arrives BEFORE audio playback starts — render product cards
+        // immediately so they appear before the assistant begins speaking.
+        if (message.type === 'tool_result' && typeof message.structuredText === 'string' && message.structuredText.trim()) {
+          setStreamingVoiceText('');
+          onVoiceMessageRef.current?.(message.structuredText, 'assistant');
+          voiceStructuredPostedRef.current = true;
+        }
+
         // Show intermediate transcript text as it streams in (alongside audio)
         if (message.type === 'transcript' && message.role === 'assistant' && !message.isFinal && message.text) {
           setStreamingVoiceText(message.text);
         }
 
         if (message.type === 'transcript' && message.role === 'assistant' && message.isFinal && message.text) {
+          // Response received — clear timeout and flag
+          awaitingResponseRef.current = false;
+          if (responseTimeoutRef.current) {
+            clearTimeout(responseTimeoutRef.current);
+            responseTimeoutRef.current = null;
+          }
+
           // Clear streaming text and add the final message to chat history
           setStreamingVoiceText('');
-          const displayText = message.text;
-          onVoiceMessageRef.current?.(displayText, 'assistant');
+          // If the structured tool result was already posted via the earlier
+          // `tool_result` event, skip re-posting on RESPONSE_DONE. Otherwise prefer
+          // structuredText (Foundry markdown for product cards) over the spoken
+          // paraphrase so cards render the same way as the text-chat path.
+          if (!voiceStructuredPostedRef.current) {
+            const displayText =
+              (typeof message.structuredText === 'string' && message.structuredText.trim())
+                ? message.structuredText
+                : message.text;
+            onVoiceMessageRef.current?.(displayText, 'assistant');
+          }
+          voiceStructuredPostedRef.current = false;
           setVoiceSessionState('idle');
           isSpeakingRef.current = false;
 
@@ -570,6 +624,17 @@ export const EnhancedChatPanel = ({
     };
 
     ws.onclose = async () => {
+      // If we were still waiting for an assistant response, the connection
+      // dropped before the answer arrived — notify the user.
+      if (awaitingResponseRef.current) {
+        awaitingResponseRef.current = false;
+        if (responseTimeoutRef.current) {
+          clearTimeout(responseTimeoutRef.current);
+          responseTimeoutRef.current = null;
+        }
+        setVoiceError('Voice connection closed before a response was received. Please try again.');
+      }
+      setStreamingVoiceText('');
       await stopMicrophoneCapture();
       setIsVoiceActive(false);
       setVoiceSessionState('idle');
@@ -698,8 +763,8 @@ export const EnhancedChatPanel = ({
               </div>
             ) : (
               <>
-                {/* Welcome Message - Only show when no messages and not loading */}
-                {messages.length === 0 && !isTyping && !isLoading && (
+                {/* Welcome Message - Only show when no messages, not loading, and no active voice session */}
+                {messages.length === 0 && !isTyping && !isLoading && voiceSessionState === 'idle' && !streamingVoiceText && (
               <div className="flex flex-col items-center justify-center text-center space-y-6 h-full min-h-[400px]">
                 {/* AI Assistant Icon */}
                 <img 
@@ -737,15 +802,19 @@ export const EnhancedChatPanel = ({
             );
             })}
             
-            {/* Streaming voice assistant transcript — shown while audio plays */}
+            {/* Streaming voice assistant — show typing indicator instead of paraphrased
+                plain text. The final message arrives with structuredText (markdown) and
+                renders as product cards, so showing the partial text here causes a visible
+                flicker (plain text → cards). The TTS audio provides the spoken feedback. */}
             {streamingVoiceText && (
               <EnhancedChatMessageBubble
                 message={{
                   id: 'voice-streaming',
-                  content: streamingVoiceText,
+                  content: '',
                   sender: 'assistant',
                   timestamp: new Date()
                 }}
+                isTyping={true}
               />
             )}
 

--- a/src/App/src/components/EnhancedChatPanel.tsx
+++ b/src/App/src/components/EnhancedChatPanel.tsx
@@ -314,6 +314,7 @@ export const EnhancedChatPanel = ({
     setIsVoiceTransitioning(true);
     sessionReadyRef.current = false;
     awaitingResponseRef.current = false;
+    voiceStructuredPostedRef.current = false;
     audioBufferQueueRef.current = [];
     if (responseTimeoutRef.current) {
       clearTimeout(responseTimeoutRef.current);
@@ -500,6 +501,7 @@ export const EnhancedChatPanel = ({
           setInputValue('');
           lastSentTranscriptRef.current = transcript;
           awaitingResponseRef.current = true;
+          voiceStructuredPostedRef.current = false;
 
           // Display user transcript in chat
           onVoiceMessageRef.current?.(transcript, 'user');
@@ -509,14 +511,19 @@ export const EnhancedChatPanel = ({
           responseTimeoutRef.current = setTimeout(() => {
             if (awaitingResponseRef.current) {
               awaitingResponseRef.current = false;
+              voiceStructuredPostedRef.current = false;
               setVoiceError('No response received. Please try again.');
               setStreamingVoiceText('');
               setVoiceSessionState('idle');
               const ws = wsRef.current;
               wsRef.current = null;
-              if (ws && ws.readyState === WebSocket.OPEN) {
-                ws.send(JSON.stringify({ type: 'stop_session' }));
-                ws.close();
+              if (ws) {
+                if (ws.readyState === WebSocket.OPEN) {
+                  ws.send(JSON.stringify({ type: 'stop_session' }));
+                }
+                if (ws.readyState !== WebSocket.CLOSED) {
+                  ws.close();
+                }
               }
             }
           }, 30_000);
@@ -526,6 +533,12 @@ export const EnhancedChatPanel = ({
         }
 
         if (message.type === 'audio_data' && message.data) {
+          // Assistant is responding — clear the no-response timeout
+          awaitingResponseRef.current = false;
+          if (responseTimeoutRef.current) {
+            clearTimeout(responseTimeoutRef.current);
+            responseTimeoutRef.current = null;
+          }
           setVoiceSessionState('speaking');
           isSpeakingRef.current = true;
           playAssistantAudioChunk(message.data, message.sampleRate || 24000);
@@ -534,6 +547,12 @@ export const EnhancedChatPanel = ({
         // Tool result arrives BEFORE audio playback starts — render product cards
         // immediately so they appear before the assistant begins speaking.
         if (message.type === 'tool_result' && typeof message.structuredText === 'string' && message.structuredText.trim()) {
+          // Assistant is responding — clear the no-response timeout
+          awaitingResponseRef.current = false;
+          if (responseTimeoutRef.current) {
+            clearTimeout(responseTimeoutRef.current);
+            responseTimeoutRef.current = null;
+          }
           setStreamingVoiceText('');
           onVoiceMessageRef.current?.(message.structuredText, 'assistant');
           voiceStructuredPostedRef.current = true;
@@ -541,6 +560,14 @@ export const EnhancedChatPanel = ({
 
         // Show intermediate transcript text as it streams in (alongside audio)
         if (message.type === 'transcript' && message.role === 'assistant' && !message.isFinal && message.text) {
+          // Assistant is responding — clear the no-response timeout
+          if (awaitingResponseRef.current) {
+            awaitingResponseRef.current = false;
+            if (responseTimeoutRef.current) {
+              clearTimeout(responseTimeoutRef.current);
+              responseTimeoutRef.current = null;
+            }
+          }
           setStreamingVoiceText(message.text);
         }
 
@@ -634,6 +661,7 @@ export const EnhancedChatPanel = ({
         }
         setVoiceError('Voice connection closed before a response was received. Please try again.');
       }
+      voiceStructuredPostedRef.current = false;
       setStreamingVoiceText('');
       await stopMicrophoneCapture();
       setIsVoiceActive(false);

--- a/src/api/app/routers/voice_live.py
+++ b/src/api/app/routers/voice_live.py
@@ -380,6 +380,21 @@ class VoiceLiveHandler:
             # Store raw Foundry result so UI shows same content as text chat
             self._last_tool_result = result_text
 
+            # Push structured tool result to UI immediately so product cards render
+            # BEFORE the realtime model starts streaming TTS audio. Without this, the
+            # audio (paraphrase) plays first and cards only appear after RESPONSE_DONE.
+            if result_text:
+                try:
+                    await self.send(
+                        {
+                            "type": "tool_result",
+                            "role": "assistant",
+                            "structuredText": result_text,
+                        }
+                    )
+                except Exception as exc:
+                    logger.debug("[%s] tool_result send failed: %s", self.client_id, exc)
+
             try:
                 from azure.ai.voicelive.models import ConversationRequestItem
                 tool_output = ConversationRequestItem(type="function_call_output")


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* This pull request introduces several improvements to the voice chat experience, focusing on reliability, user feedback, and the handling of structured tool results (such as product cards) in the chat UI. The changes ensure that structured results are displayed promptly, duplicate messages are avoided, and users receive clear feedback if the assistant fails to respond. Additionally, the welcome message and streaming transcript behaviors have been refined for a smoother user experience.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->