### PR TITLE
fix: Voice chat message ordering and premature listening state

### DIFF
--- a/src/App/src/App.tsx
+++ b/src/App/src/App.tsx
@@ -8,7 +8,7 @@ import { addToCart, checkoutCart, clearCurrentSessionId, createNewChatSession, c
 import { filterProducts, sortProducts } from '@/lib/data';
 import { ChatMessage, Product, SortBy } from '@/lib/types';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { toast } from 'sonner';
 
 function App() {
@@ -185,42 +185,54 @@ function App() {
 
 
   // Chat functions
-  const handleVoiceMessage = async (text: string, role: 'user' | 'assistant') => {
-    // Use localStorage fallback to avoid race where React state hasn't
-    // propagated the newly created session ID yet.
-    let sessionId = currentSessionId || getCurrentSessionId();
 
-    // Create a chat session on the first voice message so the prompt is
-    // stored under a real session key and the welcome screen is replaced.
-    if (!sessionId && role === 'user') {
-      try {
-        const sessionData = await createNewChatSession();
-        sessionId = sessionData.session_id;
-        setCurrentSessionId(sessionId);
-        saveCurrentSessionId(sessionId);
-      } catch {
-        toast.error('Failed to start chat session');
-        return;
-      }
-    }
+  // Serialise voice message handling so the user message (including session
+  // creation and its DB save) always completes before the assistant message
+  // is processed. Without this, the two fire-and-forget calls from the
+  // WebSocket handler race and the assistant save can reach the server first,
+  // causing wrong message order in the DB and in the UI after a refetch.
+  const voiceMessageQueueRef = useRef<Promise<void>>(Promise.resolve());
 
-    // Guard: if sessionId is still null (e.g. assistant message arrived
-    // before session was created), skip to avoid writing to ['chat', null].
-    if (!sessionId) {
-      return;
-    }
+  const handleVoiceMessage = (text: string, role: 'user' | 'assistant') => {
+    voiceMessageQueueRef.current = voiceMessageQueueRef.current
+      .catch(() => { /* don't let a failed save block the queue */ })
+      .then(async () => {
+        // Use localStorage fallback to avoid race where React state hasn't
+        // propagated the newly created session ID yet.
+        let sessionId = currentSessionId || getCurrentSessionId();
 
-    const msg: ChatMessage = {
-      id: `voice-${role}-${Date.now()}`,
-      content: text,
-      sender: role,
-      timestamp: createTimestamp()
-    };
-    queryClient.setQueryData(['chat', sessionId], (old: ChatMessage[] = []) => [...old, msg]);
-    if (role === 'assistant') {
-      setIsTyping(false);
-    }
-    saveVoiceMessage(sessionId, text, role);
+        // Create a chat session on the first voice message so the prompt is
+        // stored under a real session key and the welcome screen is replaced.
+        if (!sessionId && role === 'user') {
+          try {
+            const sessionData = await createNewChatSession();
+            sessionId = sessionData.session_id;
+            setCurrentSessionId(sessionId);
+            saveCurrentSessionId(sessionId);
+          } catch {
+            toast.error('Failed to start chat session');
+            return;
+          }
+        }
+
+        // Guard: if sessionId is still null (e.g. assistant message arrived
+        // before session was created), skip to avoid writing to ['chat', null].
+        if (!sessionId) {
+          return;
+        }
+
+        const msg: ChatMessage = {
+          id: `voice-${role}-${Date.now()}`,
+          content: text,
+          sender: role,
+          timestamp: createTimestamp()
+        };
+        queryClient.setQueryData(['chat', sessionId], (old: ChatMessage[] = []) => [...old, msg]);
+        if (role === 'assistant') {
+          setIsTyping(false);
+        }
+        await saveVoiceMessage(sessionId, text, role);
+      });
   };
 
   const handleSendMessage = async (content: string) => {

--- a/src/App/src/components/EnhancedChatPanel.tsx
+++ b/src/App/src/components/EnhancedChatPanel.tsx
@@ -70,6 +70,11 @@ export const EnhancedChatPanel = ({
   // result to chat history (via the early `tool_result` event). When true, the
   // final RESPONSE_DONE transcript skips re-posting to avoid duplicates.
   const voiceStructuredPostedRef = useRef(false);
+  // Buffer for tool_result text that arrives before the user transcript (transcription
+  // is async in Azure Voice Live and can lag behind the function-call response).
+  const pendingToolResultRef = useRef<string | null>(null);
+  // Whether the user transcript for the current turn has been posted to chat history.
+  const userTranscriptPostedRef = useRef(false);
 
   isTypingRef.current = isTyping;
   isLoadingRef.current = isLoading;
@@ -315,6 +320,8 @@ export const EnhancedChatPanel = ({
     sessionReadyRef.current = false;
     awaitingResponseRef.current = false;
     voiceStructuredPostedRef.current = false;
+    pendingToolResultRef.current = null;
+    userTranscriptPostedRef.current = false;
     audioBufferQueueRef.current = [];
     if (responseTimeoutRef.current) {
       clearTimeout(responseTimeoutRef.current);
@@ -437,7 +444,9 @@ export const EnhancedChatPanel = ({
     try {
       await startMicrophoneCapture();
       setIsVoiceActive(true);
-      setVoiceSessionState('listening');
+      // Stay in 'connecting' — the 'listening' state is set when the
+      // WebSocket session_started event arrives, which means the backend
+      // is actually ready to accept audio input.
     } catch (micError) {
       console.error('Unable to start microphone capture', micError);
       setVoiceError('Microphone access failed. Check browser permissions and try again.');
@@ -501,10 +510,18 @@ export const EnhancedChatPanel = ({
           setInputValue('');
           lastSentTranscriptRef.current = transcript;
           awaitingResponseRef.current = true;
-          voiceStructuredPostedRef.current = false;
 
           // Display user transcript in chat
           onVoiceMessageRef.current?.(transcript, 'user');
+          userTranscriptPostedRef.current = true;
+
+          // If the tool_result arrived before the transcription completed
+          // (Azure Voice Live transcription is async), flush the buffered
+          // assistant message now so it appears AFTER the user message.
+          if (pendingToolResultRef.current) {
+            onVoiceMessageRef.current?.(pendingToolResultRef.current, 'assistant');
+            pendingToolResultRef.current = null;
+          }
 
           // Timeout: if no assistant response within 30s, show error
           if (responseTimeoutRef.current) clearTimeout(responseTimeoutRef.current);
@@ -544,8 +561,9 @@ export const EnhancedChatPanel = ({
           playAssistantAudioChunk(message.data, message.sampleRate || 24000);
         }
 
-        // Tool result arrives BEFORE audio playback starts — render product cards
-        // immediately so they appear before the assistant begins speaking.
+        // Tool result from the Foundry agent. If the user transcript has already
+        // been posted we can render the assistant message immediately; otherwise
+        // buffer it so that the user message always appears first in chat.
         if (message.type === 'tool_result' && typeof message.structuredText === 'string' && message.structuredText.trim()) {
           // Assistant is responding — clear the no-response timeout
           awaitingResponseRef.current = false;
@@ -554,7 +572,13 @@ export const EnhancedChatPanel = ({
             responseTimeoutRef.current = null;
           }
           setStreamingVoiceText('');
-          onVoiceMessageRef.current?.(message.structuredText, 'assistant');
+          if (userTranscriptPostedRef.current) {
+            // User message already in chat — safe to post assistant immediately
+            onVoiceMessageRef.current?.(message.structuredText, 'assistant');
+          } else {
+            // Transcription still pending — buffer until user message is posted
+            pendingToolResultRef.current = message.structuredText;
+          }
           voiceStructuredPostedRef.current = true;
         }
 
@@ -593,6 +617,8 @@ export const EnhancedChatPanel = ({
             onVoiceMessageRef.current?.(displayText, 'assistant');
           }
           voiceStructuredPostedRef.current = false;
+          pendingToolResultRef.current = null;
+          userTranscriptPostedRef.current = false;
           setVoiceSessionState('idle');
           isSpeakingRef.current = false;
 
@@ -662,6 +688,8 @@ export const EnhancedChatPanel = ({
         setVoiceError('Voice connection closed before a response was received. Please try again.');
       }
       voiceStructuredPostedRef.current = false;
+      pendingToolResultRef.current = null;
+      userTranscriptPostedRef.current = false;
       setStreamingVoiceText('');
       await stopMicrophoneCapture();
       setIsVoiceActive(false);


### PR DESCRIPTION
## Purpose
* Fix race condition in voice chat where assistant response appears before the user's question in the chat panel, followed by a duplicate assistant message
* Fix premature "Listening — speak now" status showing before the WebSocket session is actually ready to accept audio input

## Does this introduce a breaking change?
- [ ] Yes
- [x] No

## How to Test
* Get the code

```bash
git clone https://github.com/microsoft/customer-chatbot-solution-accelerator.git
cd customer-chatbot-solution-accelerator
git checkout voice-bugfix-prdc
```

* Test the code
  1. Start the app locally or deploy to Azure
  2. Open the chat panel and click the mic (voice) button
  3. Verify that **"Starting voice..."** is shown while connecting, and **"Listening — speak now"** only appears after the session is established
  4. Ask a question using voice and verify that messages appear in the correct order: **user question first, then assistant response** (no duplicates)
  5. Test multiple voice turns to confirm ordering is consistent

## What to Check
Verify that the following are valid
* Voice messages appear in correct chronological order (user question → assistant answer)
* No duplicate assistant messages in the chat panel after a voice interaction
* "Starting voice..." is displayed while the WebSocket session initializes
* "Listening — speak now" only appears after the backend confirms session readiness
* The `save-voice-message` API calls reach the server in the correct order (user before assistant)

## Other Information
### Changes made:

**1. Serialized voice message saves (App.tsx)**
- Added a promise queue (`voiceMessageQueueRef`) so `handleVoiceMessage` calls are processed sequentially
- The assistant message save now waits for the user message save (including session creation) to complete before executing
- Changed `saveVoiceMessage` from fire-and-forget to awaited inside the queue

**2. Fixed tool_result / transcript race condition (EnhancedChatPanel.tsx)**
- Azure Voice Live transcription is async — the `tool_result` (assistant response) can arrive before the user's final transcript
- Added `pendingToolResultRef` to buffer the assistant tool result when it arrives before the user transcript
- Added `userTranscriptPostedRef` to track whether the user message has been posted for the current turn
- The user transcript handler now flushes any buffered tool result after posting the user message, guaranteeing correct order
- Removed the erroneous `voiceStructuredPostedRef = false` reset in the user transcript handler that was defeating the duplicate guard

**3. Fixed premature listening state (EnhancedChatPanel.tsx)**
- Removed `setVoiceSessionState('listening')` after mic capture — the state now stays in "connecting" until the backend's `session_started` WebSocket event confirms readiness
