### PR TITLE
fix: Fix for UI bugs in BYOCC

### DIFF
--- a/src/App/src/components/EnhancedChatPanel.tsx
+++ b/src/App/src/components/EnhancedChatPanel.tsx
@@ -20,6 +20,7 @@ interface EnhancedChatPanelProps {
   onAddToCart?: (product: Product) => void;
   className?: string;
   isLoading?: boolean;
+  onVoiceProcessingChange?: (isProcessing: boolean) => void;
 }
 
 export const EnhancedChatPanel = ({
@@ -32,6 +33,7 @@ export const EnhancedChatPanel = ({
   onAddToCart,
   className,
   isLoading = false,
+  onVoiceProcessingChange,
 }: EnhancedChatPanelProps) => {
   const [inputValue, setInputValue] = useState('');
   const [isVoiceActive, setIsVoiceActive] = useState(false);
@@ -43,6 +45,7 @@ export const EnhancedChatPanel = ({
   const [voiceSessionState, setVoiceSessionState] = useState<'idle' | 'connecting' | 'listening' | 'thinking' | 'speaking'>('idle');
   const [isVoiceTransitioning, setIsVoiceTransitioning] = useState(false);
   const [streamingVoiceText, setStreamingVoiceText] = useState('');
+  const [isVoiceProcessing, setIsVoiceProcessing] = useState(false);
   const scrollAreaRef = useRef<HTMLDivElement>(null);
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -60,6 +63,7 @@ export const EnhancedChatPanel = ({
   const isLoadingRef = useRef(isLoading);
   const onSendMessageRef = useRef(onSendMessage);
   const onVoiceMessageRef = useRef(onVoiceMessage);
+  const onVoiceProcessingChangeRef = useRef(onVoiceProcessingChange);
   const voiceConfigCacheRef = useRef<any>(null);
   const audioBufferQueueRef = useRef<string[]>([]);
   const sessionReadyRef = useRef(false);
@@ -75,6 +79,7 @@ export const EnhancedChatPanel = ({
   isLoadingRef.current = isLoading;
   onSendMessageRef.current = onSendMessage;
   onVoiceMessageRef.current = onVoiceMessage;
+  onVoiceProcessingChangeRef.current = onVoiceProcessingChange;
   const speakingMessageIdRef = useRef<string | null>(null);
 
   const getVoiceMessageKey = (message: ChatMessage, index: number): string => {
@@ -209,6 +214,13 @@ export const EnhancedChatPanel = ({
       handleSend();
     }
   };
+
+  // Derive voice processing state from voiceSessionState
+  useEffect(() => {
+    const processing = voiceSessionState === 'thinking' || voiceSessionState === 'speaking';
+    setIsVoiceProcessing(processing);
+    onVoiceProcessingChangeRef.current?.(processing);
+  }, [voiceSessionState]);
 
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
@@ -875,8 +887,8 @@ export const EnhancedChatPanel = ({
             value={inputValue}
             onChange={(e) => setInputValue(e.target.value)}
             onKeyDown={handleKeyPress}
-            className="pr-16 resize-none min-h-[40px]"
-            disabled={isTyping || isLoading}
+            className="pr-21 resize-none min-h-[40px]"
+            disabled={isTyping || isLoading || isVoiceProcessing}
           />
           <div className="absolute right-1 top-1/2 transform -translate-y-1/2 flex gap-1">
             <Button
@@ -905,6 +917,9 @@ export const EnhancedChatPanel = ({
                 !isVoiceEnabled
                 || isVoiceTransitioning
                 || voiceSessionState === 'thinking'
+                || isVoiceProcessing
+                || isTyping 
+                || isLoading
               }
             >
               {isVoiceActive && voiceSessionState === 'listening' && (
@@ -924,7 +939,7 @@ export const EnhancedChatPanel = ({
               className="h-8 w-8 p-0"
               title="Send message"
               onClick={handleSend}
-              disabled={!inputValue.trim() || isTyping || isLoading}
+              disabled={!inputValue.trim() || isTyping || isLoading || isVoiceProcessing}
             >
               <Send20Regular className="h-4 w-4" />
             </Button>

--- a/src/App/src/components/Layout/ChatSidebar.tsx
+++ b/src/App/src/components/Layout/ChatSidebar.tsx
@@ -2,7 +2,7 @@ import { EnhancedChatPanel } from '@/components/EnhancedChatPanel';
 import { ChatMessage, Product } from '@/lib/types';
 import { Button } from '@fluentui/react-components';
 import { Edit20Regular } from '@fluentui/react-icons';
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import PanelRight from './PanelRight';
 import PanelRightToolbar from './PanelRightToolbar';
 import eventBus from './eventbus';
@@ -30,6 +30,7 @@ export const ChatSidebar: React.FC<ChatSidebarProps> = ({
   isLoading = false,
   onAddToCart
 }) => {
+  const [isVoiceProcessing, setIsVoiceProcessing] = useState(false);
   // Sync the panel state with the isOpen prop
   useEffect(() => {
     if (isOpen) {
@@ -55,7 +56,7 @@ export const ChatSidebar: React.FC<ChatSidebarProps> = ({
           onClick={onNewChat || (() => {})}
           aria-label="Start new chat"
           title="Start new chat"
-          disabled={isTyping || isLoading}
+          disabled={isTyping || isLoading || isVoiceProcessing}
         />
       </PanelRightToolbar>
       
@@ -69,6 +70,7 @@ export const ChatSidebar: React.FC<ChatSidebarProps> = ({
           isOpen={isOpen}
           onClose={onClose || (() => {})}
           onAddToCart={onAddToCart}
+          onVoiceProcessingChange={setIsVoiceProcessing}
           className="h-full"
         />
       </div>


### PR DESCRIPTION
## Purpose

Bug list 
1. [BYOCC][DEV] - When the user submits a prompt using voice, both the Ask section and the new chat button should be disabled while the response is being processed.
2. [BYOCC][DEV] - There should be some space between the typing area and the microphone button, as they overlap when hovering and appear too close together.
3. [BYOCC][DEV] - When I send a prompt by typing, the microphone button should be disabled, just like the send button.

This pull request enhances the voice interaction experience in the chat panel by introducing a new mechanism to track and communicate the voice processing state. This allows parent components to respond to voice processing events and improves UI responsiveness by disabling certain actions while voice processing is active.

**Voice Processing State Management:**

* Added an `onVoiceProcessingChange` callback prop to `EnhancedChatPanel`, which is called whenever the voice processing state changes. This allows parent components, such as `ChatSidebar`, to be notified when voice processing is active. [[1]](diffhunk://#diff-f961ec56a491490e7481f09187cd629452d93ca72f0cf6bccc9af3967fe967d5R23) [[2]](diffhunk://#diff-f961ec56a491490e7481f09187cd629452d93ca72f0cf6bccc9af3967fe967d5R36) [[3]](diffhunk://#diff-f961ec56a491490e7481f09187cd629452d93ca72f0cf6bccc9af3967fe967d5R66) [[4]](diffhunk://#diff-f961ec56a491490e7481f09187cd629452d93ca72f0cf6bccc9af3967fe967d5R82) [[5]](diffhunk://#diff-f961ec56a491490e7481f09187cd629452d93ca72f0cf6bccc9af3967fe967d5R218-R224)
* Introduced local `isVoiceProcessing` state in `EnhancedChatPanel`, which is set based on the current `voiceSessionState` (specifically, when in 'thinking' or 'speaking' states). [[1]](diffhunk://#diff-f961ec56a491490e7481f09187cd629452d93ca72f0cf6bccc9af3967fe967d5R48) [[2]](diffhunk://#diff-f961ec56a491490e7481f09187cd629452d93ca72f0cf6bccc9af3967fe967d5R218-R224)

**UI Behavior Improvements:**

* Disabled input elements and action buttons (send message, voice, and new chat) when `isVoiceProcessing` is true, preventing user actions that could interfere with ongoing voice processing. [[1]](diffhunk://#diff-f961ec56a491490e7481f09187cd629452d93ca72f0cf6bccc9af3967fe967d5L878-R891) [[2]](diffhunk://#diff-f961ec56a491490e7481f09187cd629452d93ca72f0cf6bccc9af3967fe967d5R920-R922) [[3]](diffhunk://#diff-f961ec56a491490e7481f09187cd629452d93ca72f0cf6bccc9af3967fe967d5L927-R942) [[4]](diffhunk://#diff-3558f12d77b35f7d649f90909a26ee8c6467f953c6a37a116b88b9a10dd08a2fL58-R59)
* Increased the right padding of the chat input to accommodate UI changes.

**Parent Component Integration:**

* In `ChatSidebar`, added local state `isVoiceProcessing` and passed it to `EnhancedChatPanel` via the new callback prop, ensuring the sidebar's controls (like "Start new chat") are disabled during voice processing. [[1]](diffhunk://#diff-3558f12d77b35f7d649f90909a26ee8c6467f953c6a37a116b88b9a10dd08a2fL5-R5) [[2]](diffhunk://#diff-3558f12d77b35f7d649f90909a26ee8c6467f953c6a37a116b88b9a10dd08a2fR33) [[3]](diffhunk://#diff-3558f12d77b35f7d649f90909a26ee8c6467f953c6a37a116b88b9a10dd08a2fR73) [[4]](diffhunk://#diff-3558f12d77b35f7d649f90909a26ee8c6467f953c6a37a116b88b9a10dd08a2fL58-R59)

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [X] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->