### PR TITLE
fix: voice chat mic disable and tool_result flush fallback

### DIFF
--- a/src/App/src/components/EnhancedChatPanel.tsx
+++ b/src/App/src/components/EnhancedChatPanel.tsx
@@ -708,6 +708,10 @@ export const EnhancedChatPanel = ({
         }
         setVoiceError('Voice connection closed before a response was received. Please try again.');
       }
+      // Flush buffered answer before nulling refs to avoid silent drop on early close (#42108).
+      if (pendingToolResultRef.current && !userTranscriptPostedRef.current) {
+        onVoiceMessageRef.current?.(pendingToolResultRef.current, 'assistant');
+      }
       voiceStructuredPostedRef.current = false;
       pendingToolResultRef.current = null;
       userTranscriptPostedRef.current = false;

--- a/src/App/src/components/EnhancedChatPanel.tsx
+++ b/src/App/src/components/EnhancedChatPanel.tsx
@@ -76,6 +76,8 @@ export const EnhancedChatPanel = ({
   const pendingToolResultRef = useRef<string | null>(null);
   // Whether the user transcript for the current turn has been posted to chat history.
   const userTranscriptPostedRef = useRef(false);
+  // Fallback flush timer for buffered tool_result when user transcript never finalizes (#42108).
+  const pendingToolResultFlushTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   isTypingRef.current = isTyping;
   isLoadingRef.current = isLoading;
@@ -323,6 +325,10 @@ export const EnhancedChatPanel = ({
       clearTimeout(responseTimeoutRef.current);
       responseTimeoutRef.current = null;
     }
+    if (pendingToolResultFlushTimeoutRef.current) {
+      clearTimeout(pendingToolResultFlushTimeoutRef.current);
+      pendingToolResultFlushTimeoutRef.current = null;
+    }
 
     const ws = wsRef.current;
     wsRef.current = null;
@@ -510,6 +516,11 @@ export const EnhancedChatPanel = ({
             onVoiceMessageRef.current?.(pendingToolResultRef.current, 'assistant');
             pendingToolResultRef.current = null;
           }
+          // User transcript arrived — cancel fallback flush.
+          if (pendingToolResultFlushTimeoutRef.current) {
+            clearTimeout(pendingToolResultFlushTimeoutRef.current);
+            pendingToolResultFlushTimeoutRef.current = null;
+          }
 
           // Timeout: if no assistant response within 30s, show error
           if (responseTimeoutRef.current) clearTimeout(responseTimeoutRef.current);
@@ -566,6 +577,19 @@ export const EnhancedChatPanel = ({
           } else {
             // Transcription still pending — buffer until user message is posted
             pendingToolResultRef.current = message.structuredText;
+            // Fallback: flush buffered answer after 5s if user transcript never arrives (#42108).
+            if (pendingToolResultFlushTimeoutRef.current) {
+              clearTimeout(pendingToolResultFlushTimeoutRef.current);
+            }
+            pendingToolResultFlushTimeoutRef.current = setTimeout(() => {
+              pendingToolResultFlushTimeoutRef.current = null;
+              const buffered = pendingToolResultRef.current;
+              if (buffered && !userTranscriptPostedRef.current) {
+                // Skip synthesizing user message — lastSentTranscriptRef may hold a stale prior turn.
+                onVoiceMessageRef.current?.(buffered, 'assistant');
+                pendingToolResultRef.current = null;
+              }
+            }, 5_000);
           }
           voiceStructuredPostedRef.current = true;
         }
@@ -605,6 +629,13 @@ export const EnhancedChatPanel = ({
                 ? message.structuredText
                 : message.text;
             onVoiceMessageRef.current?.(displayText, 'assistant');
+          } else if (pendingToolResultRef.current && !userTranscriptPostedRef.current) {
+            // Flush buffered answer instead of silent drop (#42108).
+            onVoiceMessageRef.current?.(pendingToolResultRef.current, 'assistant');
+          }
+          if (pendingToolResultFlushTimeoutRef.current) {
+            clearTimeout(pendingToolResultFlushTimeoutRef.current);
+            pendingToolResultFlushTimeoutRef.current = null;
           }
           voiceStructuredPostedRef.current = false;
           pendingToolResultRef.current = null;
@@ -680,6 +711,10 @@ export const EnhancedChatPanel = ({
       voiceStructuredPostedRef.current = false;
       pendingToolResultRef.current = null;
       userTranscriptPostedRef.current = false;
+      if (pendingToolResultFlushTimeoutRef.current) {
+        clearTimeout(pendingToolResultFlushTimeoutRef.current);
+        pendingToolResultFlushTimeoutRef.current = null;
+      }
       setStreamingVoiceText('');
       await stopMicrophoneCapture();
       setIsVoiceActive(false);
@@ -914,8 +949,9 @@ export const EnhancedChatPanel = ({
                 || isVoiceTransitioning
                 || voiceSessionState === 'thinking'
                 || isVoiceProcessing
-                || isTyping 
+                || isTyping
                 || isLoading
+                || inputValue.trim().length > 0
               }
             >
               {isVoiceActive && voiceSessionState === 'listening' && (


### PR DESCRIPTION
## Purpose

This pull request fixes two voice-chat regressions in the `EnhancedChatPanel` component:

* **#42113 — Microphone button not disabled while typing.** The mic button now disables as soon as the user has typed text in the input, mirroring the Send button''s enable condition.
* **#42108 — Voice input intermittently produces no response.** When Azure Voice Live transcription lags behind the function-call response, the buffered `tool_result` could be silently dropped. The fix adds a 5s fallback flush timer plus safety flushes in the assistant `transcript isFinal` handler and `ws.onclose` so the answer is always surfaced to the user.

## Changes

* **Mic disable on input (#42113):** added `inputValue.trim().length > 0` to the voice toggle button''s `disabled` condition.
* **Tool-result fallback timer (#42108):** new `pendingToolResultFlushTimeoutRef` arms a 5s timer when `tool_result` arrives before the user transcript final; flushes the buffered assistant answer if the user transcript never arrives. Cancelled when user transcript final fires within 5s.
* **Safety flush in assistant `transcript isFinal`:** if a tool_result is still buffered and user transcript never arrived, post the answer instead of nulling silently.
* **Safety flush in `ws.onclose`:** if the socket closes within the 5s fallback window with the buffer still set, post the answer before clearing refs (Copilot review fix).
* The new timer is cleared in `stopVoiceSession`, `ws.onclose`, both flush paths, and the user-transcript-final branch to avoid leaking across turns.

We deliberately do **not** synthesize a user message from `lastSentTranscriptRef` in the fallback paths — that ref is not reset between turns and could hold a previous turn''s transcript.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## How to Test

```
git clone https://github.com/microsoft/customer-chatbot-solution-accelerator.git
cd customer-chatbot-solution-accelerator
git checkout bugfix/speech
cd src/App && npm install --legacy-peer-deps && npm run dev
```

**Mic disable test (#42113):** type into the chat input → mic button greys out and is disabled.
**Voice fallback test (#42108):** click mic, ask a product question. Even when transcription drops, the answer card appears within 5s instead of nothing.

## What to Check

* Mic button disables when there is typed text and re-enables when the input is cleared.
* Voice answers always appear in chat (no silent drops on dropped transcripts or early WS close).
* No regression in normal voice flow (user transcript + tool_result + audio arrive in order).
* Golden path testing passes.
