### PR TITLE
test: Customer chatbot e2e test fixed flaky tests

### DIFF
--- a/tests/e2e-test/pages/webUserPage.py
+++ b/tests/e2e-test/pages/webUserPage.py
@@ -32,15 +32,11 @@ class WebUserPage(BasePage):
             timeout=10000
         )
         send_button.click()
-        # First wait for generation to actually START (stop button appears),
-        # then wait for it to finish. Without the appear-wait, wait_for(state="hidden")
-        # returns immediately if the stop button hasn't mounted yet, causing the test
-        # to read a stale/empty response.
+        # Wait for stop button to appear before waiting for hidden; otherwise hidden returns immediately.
         stop_btn = self.page.locator(self.STOP_GENERATING_LABEL)
         try:
             stop_btn.wait_for(state="visible", timeout=15000)
         except PlaywightTimeoutError:
-            # Some very short replies may never render the stop button; that's OK.
             pass
         stop_btn.wait_for(state="hidden", timeout=60000)
 
@@ -54,14 +50,11 @@ class WebUserPage(BasePage):
 
     def wait_for_response(self, timeout=30000):
         """Wait for the chat response to appear"""
-        # Wait for stop generating button to appear first, then disappear.
-        # state="hidden" alone returns immediately when the element isn't mounted yet,
-        # which races against slow/cold-start backends.
+        # Wait for stop button to appear before waiting for hidden; otherwise hidden returns immediately.
         stop_btn = self.page.locator(self.STOP_GENERATING_LABEL)
         try:
             stop_btn.wait_for(state="visible", timeout=15000)
         except Exception:
-            # Stop button may not appear for very short replies; continue.
             pass
         try:
             stop_btn.wait_for(state="hidden", timeout=timeout)
@@ -248,9 +241,7 @@ class WebUserPage(BasePage):
         # Wait for response with longer timeout
         self.wait_for_response(timeout=45000)
         
-        # Wait for a NEW response to appear (response count must increase).
-        # Previously this silently swallowed timeouts, causing the test to read
-        # the prior (stale) AI bubble and assert against the wrong question.
+        # Fail loudly if no new bubble appears; swallowing here causes stale-response assertions.
         try:
             self.page.wait_for_function(
                 f"""(expectedCount) => {{
@@ -268,11 +259,7 @@ class WebUserPage(BasePage):
         
         # Wait extra time to ensure new response has fully loaded
         self.page.wait_for_timeout(5000)
-        
-        # Read the NEW bubble directly by index (deterministic).
-        # The previous heuristic-based get_latest_ai_response() could silently
-        # fall back to an earlier bubble when the new response tripped the
-        # product-card filter, causing stale-text assertions.
+
         response = self.get_new_ai_response(initial_response_count)
         
         # Verify response contains expected content
@@ -281,18 +268,11 @@ class WebUserPage(BasePage):
         return response, contains_keyword, found_keyword
 
     def get_new_ai_response(self, initial_count):
-        """Return the text of the newly appended AI response bubble.
-
-        Deterministic: picks the last bubble strictly after `initial_count`,
-        which is the one just produced by the most recent question. Falls back
-        to the heuristic extractor only if the direct read yields nothing.
-        """
+        """Return the text of the newly appended AI response bubble."""
         import re
-        ai_response_selector = 'div[class*="bg-muted"]'
-        bubbles = self.page.locator(ai_response_selector)
+        bubbles = self.page.locator('div[class*="bg-muted"]')
         total = bubbles.count()
         if total > initial_count:
-            # The newest bubble appended after the question is the last one.
             try:
                 text = bubbles.nth(total - 1).text_content() or ""
                 cleaned = re.sub(r'\s+', ' ', text).strip()
@@ -300,7 +280,6 @@ class WebUserPage(BasePage):
                     return cleaned
             except Exception:
                 pass
-        # Fallback: heuristic extractor
         return self.get_latest_ai_response()
     
     def get_latest_ai_response(self):

--- a/tests/e2e-test/pages/webUserPage.py
+++ b/tests/e2e-test/pages/webUserPage.py
@@ -54,11 +54,12 @@ class WebUserPage(BasePage):
         stop_btn = self.page.locator(self.STOP_GENERATING_LABEL)
         try:
             stop_btn.wait_for(state="visible", timeout=15000)
-        except Exception:
+        except PlaywightTimeoutError:
+            # Short replies may never render the stop button; continue.
             pass
         try:
             stop_btn.wait_for(state="hidden", timeout=timeout)
-        except Exception:
+        except PlaywightTimeoutError:
             pass
         
         # Wait for AI response to appear by looking for response indicators
@@ -268,19 +269,32 @@ class WebUserPage(BasePage):
         return response, contains_keyword, found_keyword
 
     def get_new_ai_response(self, initial_count):
-        """Return the text of the newly appended AI response bubble."""
+        """Return the text of the newly appended AI response bubble.
+
+        Deterministic: retries reading the last bubble at index >= initial_count.
+        Does NOT fall back to the heuristic extractor on failure, because that
+        path is not parameterized by initial_count and could return a stale
+        prior bubble (the original bug this fix targets). On persistent failure
+        returns an empty string so the calling assertion fails with the actual
+        question text and diagnostic info.
+        """
         import re
         bubbles = self.page.locator('div[class*="bg-muted"]')
-        total = bubbles.count()
-        if total > initial_count:
-            try:
-                text = bubbles.nth(total - 1).text_content() or ""
-                cleaned = re.sub(r'\s+', ' ', text).strip()
-                if cleaned:
-                    return cleaned
-            except Exception:
-                pass
-        return self.get_latest_ai_response()
+        # Retry to absorb brief re-renders / hydration gaps.
+        for _ in range(5):
+            total = bubbles.count()
+            if total > initial_count:
+                try:
+                    text = bubbles.nth(total - 1).text_content() or ""
+                    cleaned = re.sub(r'\s+', ' ', text).strip()
+                    if cleaned:
+                        return cleaned
+                except PlaywightTimeoutError:
+                    pass
+                except Exception:
+                    pass
+            self.page.wait_for_timeout(1000)
+        return ""
     
     def get_latest_ai_response(self):
         """Get the text content of the LATEST/MOST RECENT AI response only"""

--- a/tests/e2e-test/pages/webUserPage.py
+++ b/tests/e2e-test/pages/webUserPage.py
@@ -32,7 +32,17 @@ class WebUserPage(BasePage):
             timeout=10000
         )
         send_button.click()
-        self.page.locator(self.STOP_GENERATING_LABEL).wait_for(state="hidden", timeout=30000)
+        # First wait for generation to actually START (stop button appears),
+        # then wait for it to finish. Without the appear-wait, wait_for(state="hidden")
+        # returns immediately if the stop button hasn't mounted yet, causing the test
+        # to read a stale/empty response.
+        stop_btn = self.page.locator(self.STOP_GENERATING_LABEL)
+        try:
+            stop_btn.wait_for(state="visible", timeout=15000)
+        except PlaywightTimeoutError:
+            # Some very short replies may never render the stop button; that's OK.
+            pass
+        stop_btn.wait_for(state="hidden", timeout=60000)
 
     def open_chat_window(self):
         """Click on the Open Chat button to open the chat window"""
@@ -44,11 +54,18 @@ class WebUserPage(BasePage):
 
     def wait_for_response(self, timeout=30000):
         """Wait for the chat response to appear"""
-        # Wait for stop generating button to disappear (indicating response is complete)
+        # Wait for stop generating button to appear first, then disappear.
+        # state="hidden" alone returns immediately when the element isn't mounted yet,
+        # which races against slow/cold-start backends.
+        stop_btn = self.page.locator(self.STOP_GENERATING_LABEL)
         try:
-            self.page.locator(self.STOP_GENERATING_LABEL).wait_for(state="hidden", timeout=timeout)
+            stop_btn.wait_for(state="visible", timeout=15000)
         except Exception:
-            # If stop generating button doesn't appear, just wait a bit
+            # Stop button may not appear for very short replies; continue.
+            pass
+        try:
+            stop_btn.wait_for(state="hidden", timeout=timeout)
+        except Exception:
             pass
         
         # Wait for AI response to appear by looking for response indicators
@@ -231,7 +248,9 @@ class WebUserPage(BasePage):
         # Wait for response with longer timeout
         self.wait_for_response(timeout=45000)
         
-        # Wait for a NEW response to appear (response count should increase)
+        # Wait for a NEW response to appear (response count must increase).
+        # Previously this silently swallowed timeouts, causing the test to read
+        # the prior (stale) AI bubble and assert against the wrong question.
         try:
             self.page.wait_for_function(
                 f"""(expectedCount) => {{
@@ -239,21 +258,50 @@ class WebUserPage(BasePage):
                     return responses.length > expectedCount;
                 }}""",
                 arg=initial_response_count,
-                timeout=60000
+                timeout=90000
             )
-        except PlaywightTimeoutError:
-            pass  # Timeout waiting for AI response is expected in some test scenarios.
+        except PlaywightTimeoutError as e:
+            raise AssertionError(
+                f"No new AI response appeared within 90s for question: {question!r}. "
+                f"Initial bubble count={initial_response_count}, still unchanged."
+            ) from e
         
         # Wait extra time to ensure new response has fully loaded
         self.page.wait_for_timeout(5000)
         
-        # Get the LATEST response specifically (the last one in the list)
-        response = self.get_latest_ai_response()
+        # Read the NEW bubble directly by index (deterministic).
+        # The previous heuristic-based get_latest_ai_response() could silently
+        # fall back to an earlier bubble when the new response tripped the
+        # product-card filter, causing stale-text assertions.
+        response = self.get_new_ai_response(initial_response_count)
         
         # Verify response contains expected content
         contains_keyword, found_keyword = self.verify_response_contains_keywords(response, expected_keywords)
         
         return response, contains_keyword, found_keyword
+
+    def get_new_ai_response(self, initial_count):
+        """Return the text of the newly appended AI response bubble.
+
+        Deterministic: picks the last bubble strictly after `initial_count`,
+        which is the one just produced by the most recent question. Falls back
+        to the heuristic extractor only if the direct read yields nothing.
+        """
+        import re
+        ai_response_selector = 'div[class*="bg-muted"]'
+        bubbles = self.page.locator(ai_response_selector)
+        total = bubbles.count()
+        if total > initial_count:
+            # The newest bubble appended after the question is the last one.
+            try:
+                text = bubbles.nth(total - 1).text_content() or ""
+                cleaned = re.sub(r'\s+', ' ', text).strip()
+                if cleaned:
+                    return cleaned
+            except Exception:
+                pass
+        # Fallback: heuristic extractor
+        return self.get_latest_ai_response()
     
     def get_latest_ai_response(self):
         """Get the text content of the LATEST/MOST RECENT AI response only"""

--- a/tests/e2e-test/tests/test_byocc.py
+++ b/tests/e2e-test/tests/test_byocc.py
@@ -61,8 +61,7 @@ class TestBYOCCGoldenPath:
         # Step 1: Open chat window
         logger.info("Opening chat window...")
         web_user_page.open_chat_window()
-        # Warm-up for cold-started Azure Web App so the first question doesn't race
-        # against backend initialization.
+        # Warm-up for cold-started Azure Web App backend.
         page.wait_for_timeout(5000)
         
         # Take screenshot after opening chat

--- a/tests/e2e-test/tests/test_byocc.py
+++ b/tests/e2e-test/tests/test_byocc.py
@@ -61,8 +61,11 @@ class TestBYOCCGoldenPath:
         # Step 1: Open chat window
         logger.info("Opening chat window...")
         web_user_page.open_chat_window()
-        # Warm-up for cold-started Azure Web App backend.
-        page.wait_for_timeout(5000)
+        # Warm-up for cold-started Azure Web App backend. Configurable so warm
+        # environments can set E2E_WARMUP_MS=0 to skip this delay.
+        warmup_ms = int(os.getenv("E2E_WARMUP_MS", "5000"))
+        if warmup_ms > 0:
+            page.wait_for_timeout(warmup_ms)
         
         # Take screenshot after opening chat
         self._take_screenshot(page, "02_chat_opened")

--- a/tests/e2e-test/tests/test_byocc.py
+++ b/tests/e2e-test/tests/test_byocc.py
@@ -61,6 +61,9 @@ class TestBYOCCGoldenPath:
         # Step 1: Open chat window
         logger.info("Opening chat window...")
         web_user_page.open_chat_window()
+        # Warm-up for cold-started Azure Web App so the first question doesn't race
+        # against backend initialization.
+        page.wait_for_timeout(5000)
         
         # Take screenshot after opening chat
         self._take_screenshot(page, "02_chat_opened")


### PR DESCRIPTION
## Purpose
This pull request improves the reliability and clarity of the end-to-end chat UI tests by refining how the test waits for UI elements and handles response validation. The main focus is on making the tests more robust against timing issues and ensuring failures are clearly reported when expected UI changes do not occur.

**Test reliability and robustness improvements:**

* In `webUserPage.py`, updated the logic in both `click_send_button` and `wait_for_response` to explicitly wait for the stop button to appear before waiting for it to disappear, preventing premature continuation if the button is never shown. Exception handling was added to avoid test failures if the button does not become visible. [[1]](diffhunk://#diff-793bafc03ad1881188556c0964d2db689b25e311524eefd640c20543616fd2afL35-R41) [[2]](diffhunk://#diff-793bafc03ad1881188556c0964d2db689b25e311524eefd640c20543616fd2afL47-L51)

* In `ask_question_and_verify`, changed the logic to fail loudly with a clear assertion error if a new AI response bubble does not appear within the timeout, instead of silently swallowing the timeout. This helps catch and diagnose UI or backend issues during testing.

**Test code clarity and maintainability:**

* Added a new helper method `get_new_ai_response` to reliably fetch the newly appended AI response, improving accuracy over always returning the latest bubble.

**Test flakiness reduction:**

* In `test_byocc.py`, added a warm-up wait after opening the chat window to account for potential cold starts in the Azure Web App backend, reducing test flakiness.
* ...

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [X ] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->