### PR TITLE
fix: fix format issue

### DIFF
--- a/src/App/src/lib/textParsers.ts
+++ b/src/App/src/lib/textParsers.ts
@@ -190,7 +190,7 @@ function normalizeOrderData(order: Partial<Order>): Order {
 export function parseProductsFromText(text: string): { products: Product[], introText: string, outroText: string } {
   const products: Product[] = [];
   
-  const parts = text.split(/(?=\d+\.\s*\*\*[^*]+\*\*)/);
+  const parts = text.split(/(?=\d+\.\s*\*\*[^*]+\*\*)|(?=\*\*\d+\.\s*[^*]+\*\*)/);
   
   let introText = '';
   let outroText = '';
@@ -206,7 +206,7 @@ export function parseProductsFromText(text: string): { products: Product[], intr
       const afterMatch = afterLastProduct.match(/!\[[^\]]*\]\([^)]*\)\.?\s*([\s\S]*?)$/);
       if (afterMatch && afterMatch[1].trim()) {
         const afterText = afterMatch[1].trim();
-        if (!afterText.match(/^\d+\.\s*\*\*/)) {
+        if (!afterText.match(/^\d+\.\s*\*\*/) && !afterText.match(/^\*\*\d+\.\s*/)) {
           outroText = afterText;
         }
       }
@@ -236,7 +236,7 @@ export function parseProductsFromText(text: string): { products: Product[], intr
 
 function parseProductSection(section: string): Product | null {
   try {
-    let nameMatch = section.match(/\d+\.\s*\*\*([^*]+)\*\*/);
+    let nameMatch = section.match(/\d+\.\s*\*\*([^*]+)\*\*/) || section.match(/\*\*\d+\.\s*([^*]+)\*\*/);
     let title = '';
     
     if (nameMatch) {
@@ -272,7 +272,7 @@ function parseProductSection(section: string): Product | null {
     
     if (!title) return null;
     
-    const priceMatch = section.match(/\*\*Price:\*\*\s*\$([0-9,]+\.?\d*)/) || section.match(/[-–]\s*Price:\s*\$([0-9,]+\.?\d*)/);
+    const priceMatch = section.match(/\*\*Price:\*\*\s*\$([0-9,]+\.?\d*)/) || section.match(/[-–]\s*Price:\s*\$([0-9,]+\.?\d*)/) || section.match(/Price:\s*\$([0-9,]+\.?\d*)/);
     const price = priceMatch ? parseFloat(priceMatch[1].replace(',', '')) : 59.50;
     
     const originalPriceMatch = section.match(/Originally \$([0-9,]+\.?\d*)/);
@@ -292,7 +292,7 @@ function parseProductSection(section: string): Product | null {
     }
     
     if (!description) {
-      const flatDescMatch = section.match(/[-–]\s*Description:\s*(.+?)(?=\s*[-–]\s*Price:|\s*[-–]\s*!\[|$)/i);
+      const flatDescMatch = section.match(/[-–]\s*Description:\s*(.+?)(?=\s*[-–]\s*Price:|\s*[-–]\s*!\[|$)/i) || section.match(/Description:\s*(.+?)(?=\s*Price:|\s*Image:|\s*!\[|$)/i);
       if (flatDescMatch) {
         description = flatDescMatch[1].trim();
       }
@@ -385,18 +385,20 @@ export function detectContentType(text: string): 'orders' | 'products' | 'text' 
     return 'orders';
   }
   
-  const hasProductFormat = /\d+\.\s*\*\*[^*]+\*\*.*!\[/s.test(text);
-  const hasPriceAndRating = (text.includes('**Price:**') || /[-–]\s*Price:\s*\$/i.test(text)) && 
+  const hasProductFormat = /\d+\.\s*\*\*[^*]+\*\*.*!\[/s.test(text) || /\*\*\d+\.\s*[^*]+\*\*.*!\[/s.test(text);
+  const hasPriceAndRating = (text.includes('**Price:**') || /[-–]\s*Price:\s*\$/i.test(text) || /\nPrice:\s*\$/i.test(text)) && 
     (text.includes('**Rating:**') || /[-–]\s*Rating:/i.test(text));
-  const hasPriceAndDescription = (text.includes('**Price:**') || /[-–]\s*Price:\s*\$/i.test(text)) &&
-    (text.includes('**Description:**') || /[-–]\s*Description:/i.test(text));
+  const hasPriceAndDescription = (text.includes('**Price:**') || /[-–]\s*Price:\s*\$/i.test(text) || /\nPrice:\s*\$/i.test(text)) &&
+    (text.includes('**Description:**') || /[-–]\s*Description:/i.test(text) || /\nDescription:/i.test(text));
   
   const hasImageOrLink = /!\[[^\]]+\]\([^)]+\)/.test(text) || /\[[^\]]+\]\([^)]+\.(jpg|jpeg|png|gif|webp|svg)/i.test(text);
   const hasImageWithDescription = hasImageOrLink && 
     (/\w+\s+is\s+(?:described\s+as|a\s+)/i.test(text) || 
      /"[^"]+"\s+is\s+(?:described\s+as|a\s+)/i.test(text));
+
+  const hasNumberedProductsWithPrice = /\*\*\d+\.\s*[^*]+\*\*/s.test(text) && /Price:\s*\$/i.test(text) && hasImageOrLink;
   
-  if (hasPriceAndRating || hasPriceAndDescription || hasProductFormat || hasImageWithDescription) {
+  if (hasPriceAndRating || hasPriceAndDescription || hasProductFormat || hasImageWithDescription || hasNumberedProductsWithPrice) {
     return 'products';
   }
   

--- a/src/App/src/lib/textParsers.ts
+++ b/src/App/src/lib/textParsers.ts
@@ -299,6 +299,19 @@ function parseProductSection(section: string): Product | null {
     }
     
     if (!description) {
+      // Implicit description: the AI sometimes omits the "Description:" label and
+      // simply writes the description paragraph between the **N. Title** heading
+      // and the Price line. Capture everything between the bold title heading and
+      // the next Price line (with or without **/dash prefixes).
+      const implicitDescMatch = section.match(
+        /(?:\*\*\d+\.\s*[^*]+\*\*|\d+\.\s*\*\*[^*]+\*\*|\*\*[^*\n]+\*\*)\s*\n+([\s\S]+?)(?=\n\s*(?:\*\*)?(?:[-–]\s*)?Price:)/i
+      );
+      if (implicitDescMatch) {
+        description = implicitDescMatch[1].trim();
+      }
+    }
+
+    if (!description) {
       const describedMatch = section.match(/"([^"]+)"\s+is\s+described\s+as\s+([^!]+?)(?=If\s+you're|!\[|$)/is);
       if (describedMatch) {
         description = describedMatch[2].trim();
@@ -324,11 +337,19 @@ function parseProductSection(section: string): Product | null {
         const textBeforeImage = beforeImageMatch[1].trim();
         const escapedTitle = title.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
         let cleanedText = textBeforeImage
+          // Strip a leading **N. Title** or **Title** heading line if present.
+          .replace(/^\s*\*\*\d+\.\s*[^*]+\*\*\s*/i, '')
+          .replace(/^\s*\d+\.\s*\*\*[^*]+\*\*\s*/i, '')
+          .replace(/^\s*\*\*[^*\n]+\*\*\s*/i, '')
           .replace(new RegExp(`^"${escapedTitle}"\\s*`, 'i'), '')
           .replace(new RegExp(`^${escapedTitle}\\s*`, 'i'), '')
           .replace(/^is\s+(?:described\s+as|a)\s+/i, '')
           .trim();
-        cleanedText = cleanedText.replace(/\s*If\s+you're\s+(?:interested|seeing)[^.]*\./i, '').trim();
+        // Strip a trailing Price: line so it doesn't leak into the description.
+        cleanedText = cleanedText
+          .replace(/\n\s*(?:\*\*)?(?:[-–]\s*)?Price:[^\n]*$/i, '')
+          .replace(/\s*If\s+you're\s+(?:interested|seeing)[^.]*\./i, '')
+          .trim();
         if (cleanedText && cleanedText.length > 10) {
           description = cleanedText;
         }


### PR DESCRIPTION
## Purpose
This pull request improves the robustness and flexibility of the product parsing logic in `textParsers.ts`, allowing the system to handle a wider variety of product text formats, especially those generated by AI that don't always follow strict templates. The changes focus on expanding regex patterns to recognize more heading and price/description styles, enhancing implicit description extraction, and improving content type detection.

**Parsing flexibility and robustness:**

* Expanded regex patterns in `parseProductsFromText` and `parseProductSection` to recognize both `N. **Title**` and `**N. Title**` heading formats, as well as price and description lines with or without markdown/dash prefixes. [[1]](diffhunk://#diff-46b03f0198616f01d8e856128d9cb3efb46cfaa9ed77f09d56a75d025069ebfcL193-R193) [[2]](diffhunk://#diff-46b03f0198616f01d8e856128d9cb3efb46cfaa9ed77f09d56a75d025069ebfcL209-R209) [[3]](diffhunk://#diff-46b03f0198616f01d8e856128d9cb3efb46cfaa9ed77f09d56a75d025069ebfcL239-R239) [[4]](diffhunk://#diff-46b03f0198616f01d8e856128d9cb3efb46cfaa9ed77f09d56a75d025069ebfcL275-R275) [[5]](diffhunk://#diff-46b03f0198616f01d8e856128d9cb3efb46cfaa9ed77f09d56a75d025069ebfcL295-R313)
* Added support for extracting implicit product descriptions when the "Description:" label is omitted, capturing the paragraph between the title and price lines.
* Improved logic for cleaning up product descriptions by stripping heading lines and trailing price lines that might leak into the description.

**Content type detection improvements:**

* Enhanced detection of product content by supporting additional heading and price/description formats, including cases without markdown or with different line prefixes.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [ ] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->