### PR TITLE
fix: images in chat

### DIFF
--- a/infra/scripts/agent_scripts/01_create_agents.py
+++ b/infra/scripts/agent_scripts/01_create_agents.py
@@ -146,13 +146,13 @@ async def create_agents():
         )
 
         # 3. Create Chat Agent — delegates to product/policy sub-agents via function tools.
-        chat_agent_instructions = """You are a helpful assistant for Contoso Paint customer support and product questions.
+        chat_agent_instructions = """You are a helpful assistant that can use the product agent and policy agent to answer user questions.
 
-                        You have two tools:
-                        - product_agent: use it for questions about paint colors, paint products, paint prices, and other color requests.
-                        - policy_agent: use it for questions about return policy, warranty information, services provided (e.g. color matching, recycling), and information about the Contoso Paint company.
+                                    Use policy_agent for: questions around return policy, warranty information, services provided(i.e. color matching, color match, recycling), and information about contoso paint company.
 
-                        ALWAYS call product_agent or policy_agent to answer product, color, price, policy, warranty, or service questions — never answer these from your own knowledge, and never make up products, prices, or image URLs. Pass the user's question as the 'task' argument.
+                                    Use product_agent for: questions about paint colors, paint price and other questions about type of colors and color requests.
+
+                                    ALWAYS call product_agent or policy_agent to answer product, color, price, policy, warranty, or service questions — never answer these from your own knowledge, and never make up products, prices, or image URLs.
 
                                     If you don't find any information in the knowledge source, please say no data found.
 

--- a/infra/scripts/agent_scripts/01_create_agents.py
+++ b/infra/scripts/agent_scripts/01_create_agents.py
@@ -7,6 +7,7 @@ from azure.ai.projects.models import (
     AzureAISearchTool,
     AzureAISearchToolResource,
     ConnectionType,
+    FunctionTool,
     PromptAgentDefinition,
 )
 from azure.identity.aio import AzureCliCredential
@@ -42,6 +43,25 @@ def build_ai_search_tool(project_connection_id: str, index_name: str) -> AzureAI
                 )
             ]
         )
+    )
+
+
+def build_subagent_tool(tool_name: str, description: str) -> FunctionTool:
+    """Build a function tool the chat agent uses to delegate to a grounded sub-agent."""
+    return FunctionTool(
+        name=tool_name,
+        description=description,
+        parameters={
+            "type": "object",
+            "properties": {
+                "task": {
+                    "type": "string",
+                    "description": f"The user's question to forward to {tool_name}",
+                }
+            },
+            "required": ["task"],
+            "additionalProperties": False,
+        },
     )
 
 
@@ -125,13 +145,14 @@ async def create_agents():
             tools=[build_ai_search_tool(ai_search_conn_id, "policies_index")],
         )
 
-        # 3. Create Chat Agent (toolless orchestrator; sub-agent tools are injected at runtime when applicable)
+        # 3. Create Chat Agent — delegates to product/policy sub-agents via function tools.
         chat_agent_instructions = """You are a helpful assistant for Contoso Paint customer support and product questions.
 
-                        Prioritize policy and service guidance for questions around return policy, warranty information,
-                        services provided (i.e. color matching, recycling), and information about Contoso Paint company.
+                        You have two tools:
+                        - product_agent: use it for questions about paint colors, paint products, paint prices, and other color requests.
+                        - policy_agent: use it for questions about return policy, warranty information, services provided (e.g. color matching, recycling), and information about the Contoso Paint company.
 
-                        Prioritize product guidance for questions about paint colors, paint prices, and other color requests.
+                        ALWAYS call product_agent or policy_agent to answer product, color, price, policy, warranty, or service questions — never answer these from your own knowledge, and never make up products, prices, or image URLs. Pass the user's question as the 'task' argument.
 
                                     If you don't find any information in the knowledge source, please say no data found.
 
@@ -157,7 +178,16 @@ async def create_agents():
             name=f"chat-agent-{solutionName}",
             model=gptModelName,
             instructions=chat_agent_instructions,
-            tools=None,  # Orchestrator: delegates to product/policy sub-agents; no direct search tools
+            tools=[
+                build_subagent_tool(
+                    "product_agent",
+                    "Delegate paint product, color, and price questions to the grounded product agent.",
+                ),
+                build_subagent_tool(
+                    "policy_agent",
+                    "Delegate return policy, warranty, services, and company-info questions to the grounded policy agent.",
+                ),
+            ],
         )
 
         # Return agent names

--- a/src/api/app/routers/chat.py
+++ b/src/api/app/routers/chat.py
@@ -422,14 +422,16 @@ async def send_message_legacy(
                     return await retrieved_agent.run(message.content)
 
             async def _run_with_foundry_agent() -> Any:
-                from agent_framework.foundry import FoundryAgent
+                from ..utils.foundry_agent_utils import _run_foundry_chat_with_routing
 
-                async with FoundryAgent(
-                    project_endpoint=ai_project_endpoint,
-                    agent_name=chat_agent_name,
+                return await _run_foundry_chat_with_routing(
+                    foundry_endpoint=ai_project_endpoint,
+                    chat_agent_name=chat_agent_name,
+                    product_agent_name=product_agent_name,
+                    policy_agent_name=policy_agent_name,
+                    question=message.content,
                     credential=credential,
-                ) as chat_agent:
-                    return await chat_agent.run(message.content)
+                )
 
             for attempt in range(max_retries):
                 try:

--- a/src/api/app/utils/foundry_agent_utils.py
+++ b/src/api/app/utils/foundry_agent_utils.py
@@ -1,10 +1,14 @@
 """
 Foundry agent utilities — call the multi-agent pipeline for grounded enterprise answers.
 """
+import json
 import logging
-from typing import Optional
+from typing import Any, Optional, Tuple
 
 logger = logging.getLogger(__name__)
+
+# Sub-agent tools baked into the chat agent definition.
+_SUBAGENT_TOOL_NAMES = {"product_agent", "policy_agent"}
 
 
 def _get_agent_provider_class():
@@ -15,6 +19,81 @@ def _get_agent_provider_class():
         return AzureAIProjectAgentProvider
     except ImportError:
         return None
+
+
+def _result_text(result: Any) -> str:
+    """Extract plain text from an Agent Framework run result."""
+    if result is None:
+        return ""
+    text = getattr(result, "text", None)
+    if text:
+        return text
+    return str(result)
+
+
+def _extract_subagent_call(result: Any) -> Optional[Tuple[str, str]]:
+    """Return (sub_agent_tool_name, task) if the chat agent emitted a sub-agent call, else None."""
+    messages = getattr(result, "messages", None) or []
+    for message in messages:
+        for content in getattr(message, "contents", None) or []:
+            if getattr(content, "type", None) != "function_call":
+                continue
+            name = getattr(content, "name", None)
+            if name not in _SUBAGENT_TOOL_NAMES:
+                continue
+            task = ""
+            raw_args = getattr(content, "arguments", None)
+            if raw_args:
+                try:
+                    parsed = json.loads(raw_args) if isinstance(raw_args, str) else raw_args
+                    if isinstance(parsed, dict):
+                        task = parsed.get("task") or parsed.get("query") or ""
+                except (ValueError, TypeError):
+                    task = ""
+            return name, task
+    return None
+
+
+async def _run_foundry_chat_with_routing(
+    foundry_endpoint: str,
+    chat_agent_name: str,
+    product_agent_name: str,
+    policy_agent_name: str,
+    question: str,
+    credential: Any,
+) -> str:
+    """Run the chat agent, then execute the grounded sub-agent it routes to (if any)."""
+    from agent_framework.foundry import FoundryAgent
+
+    tool_to_agent_name = {
+        "product_agent": product_agent_name,
+        "policy_agent": policy_agent_name,
+    }
+
+    async with FoundryAgent(
+        project_endpoint=foundry_endpoint,
+        agent_name=chat_agent_name,
+        credential=credential,
+    ) as chat_agent:
+        result = await chat_agent.run(question)
+
+    call = _extract_subagent_call(result)
+    if call is None:
+        return _result_text(result)
+
+    tool_name, task = call
+    target_agent_name = tool_to_agent_name.get(tool_name)
+    if not target_agent_name:
+        return _result_text(result)
+
+    async with FoundryAgent(
+        project_endpoint=foundry_endpoint,
+        agent_name=target_agent_name,
+        credential=credential,
+    ) as sub_agent:
+        sub_result = await sub_agent.run(task or question)
+
+    return _result_text(sub_result)
 
 
 async def call_foundry_agent(
@@ -83,14 +162,15 @@ async def call_foundry_agent(
 
                     result = await retrieved_agent.run(question)
             else:
-                from agent_framework.foundry import FoundryAgent
-
-                async with FoundryAgent(
-                    project_endpoint=foundry_endpoint,
-                    agent_name=chat_agent_name,
+                grounded_text = await _run_foundry_chat_with_routing(
+                    foundry_endpoint=foundry_endpoint,
+                    chat_agent_name=chat_agent_name,
+                    product_agent_name=product_agent_name,
+                    policy_agent_name=policy_agent_name,
+                    question=question,
                     credential=credential,
-                ) as chat_agent:
-                    result = await chat_agent.run(question)
+                )
+                return grounded_text or "No response from the agent."
 
             if result and hasattr(result, "text"):
                 return result.text

--- a/src/api/app/utils/foundry_agent_utils.py
+++ b/src/api/app/utils/foundry_agent_utils.py
@@ -3,12 +3,26 @@ Foundry agent utilities — call the multi-agent pipeline for grounded enterpris
 """
 import json
 import logging
+import re
 from typing import Any, Optional, Tuple
 
 logger = logging.getLogger(__name__)
 
 # Sub-agent tools baked into the chat agent definition.
 _SUBAGENT_TOOL_NAMES = {"product_agent", "policy_agent"}
+
+# Azure AI Search citation annotations, e.g. "【4:0†source】".
+_CITATION_RE = re.compile(r"\u3010[^\u3011]*?\u2020[^\u3011]*?\u3011")
+
+
+def _strip_citations(text: str) -> str:
+    """Remove Azure AI Search citation markers and tidy leftover spacing."""
+    if not text:
+        return text
+    cleaned = _CITATION_RE.sub("", text)
+    cleaned = re.sub(r"[ \t]+([.,;:!?])", r"\1", cleaned)
+    cleaned = re.sub(r"[ \t]{2,}", " ", cleaned)
+    return cleaned.strip()
 
 
 def _get_agent_provider_class():
@@ -26,9 +40,9 @@ def _result_text(result: Any) -> str:
     if result is None:
         return ""
     text = getattr(result, "text", None)
-    if text:
-        return text
-    return str(result)
+    if not text:
+        text = str(result)
+    return _strip_citations(text)
 
 
 def _extract_subagent_call(result: Any) -> Optional[Tuple[str, str]]:

--- a/src/tests/utils/test_foundry_agent_utils.py
+++ b/src/tests/utils/test_foundry_agent_utils.py
@@ -2,9 +2,17 @@
 Tests for app.utils.foundry_agent_utils — call_foundry_agent function.
 """
 import sys
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+
+
+def _function_call_result(name, arguments):
+    """Build a run-result whose message contains a single function_call content."""
+    content = SimpleNamespace(type="function_call", name=name, arguments=arguments)
+    message = SimpleNamespace(contents=[content])
+    return SimpleNamespace(messages=[message], text="")
 
 
 @pytest.mark.asyncio
@@ -234,3 +242,134 @@ async def test_foundry_agent_exception():
         )
 
     assert "error" in result.lower()
+
+
+# ---------------------------------------------------------------------------
+# Routing-path helpers (used when agent_framework.azure provider is unavailable)
+# ---------------------------------------------------------------------------
+
+
+def test_strip_citations_removes_markers():
+    """Azure AI Search citation markers are stripped and spacing tidied."""
+    from app.utils.foundry_agent_utils import _strip_citations
+
+    text = "Warranty is 2 years\u30104:0\u2020source\u3011 for all paints\u30102:1\u2020source\u3011."
+    assert _strip_citations(text) == "Warranty is 2 years for all paints."
+
+
+def test_strip_citations_tidies_space_before_punctuation():
+    """A marker sitting before punctuation does not leave a dangling space."""
+    from app.utils.foundry_agent_utils import _strip_citations
+
+    assert _strip_citations("Price is great \u30100:0\u2020source\u3011!") == "Price is great!"
+
+
+def test_strip_citations_passthrough_and_empty():
+    """Text without markers is returned unchanged; falsy input is preserved."""
+    from app.utils.foundry_agent_utils import _strip_citations
+
+    assert _strip_citations("No citations here.") == "No citations here."
+    assert _strip_citations("") == ""
+
+
+def test_result_text_extracts_and_strips():
+    """_result_text reads .text and applies citation stripping."""
+    from app.utils.foundry_agent_utils import _result_text
+
+    result = SimpleNamespace(text="Hello\u30101:0\u2020source\u3011")
+    assert _result_text(result) == "Hello"
+    assert _result_text(None) == ""
+
+
+def test_extract_subagent_call_parses_name_and_task():
+    """A product/policy function_call yields its tool name and task argument."""
+    from app.utils.foundry_agent_utils import _extract_subagent_call
+
+    result = _function_call_result("product_agent", '{"task": "find blue paint"}')
+    assert _extract_subagent_call(result) == ("product_agent", "find blue paint")
+
+
+def test_extract_subagent_call_query_fallback_and_bad_json():
+    """Falls back to 'query' arg and tolerates malformed argument JSON."""
+    from app.utils.foundry_agent_utils import _extract_subagent_call
+
+    assert _extract_subagent_call(
+        _function_call_result("policy_agent", '{"query": "returns"}')
+    ) == ("policy_agent", "returns")
+    assert _extract_subagent_call(
+        _function_call_result("policy_agent", "not-json")
+    ) == ("policy_agent", "")
+
+
+def test_extract_subagent_call_none_when_no_match():
+    """Returns None for unrecognised tools or when there is no function_call."""
+    from app.utils.foundry_agent_utils import _extract_subagent_call
+
+    assert _extract_subagent_call(_function_call_result("other_tool", "{}")) is None
+    assert _extract_subagent_call(SimpleNamespace(messages=[])) is None
+
+
+def _foundry_agent_factory(run_results):
+    """Build a FoundryAgent mock whose async-context run() returns queued results."""
+    calls = []
+
+    def _make(*_args, **kwargs):
+        agent = AsyncMock()
+        agent.__aenter__ = AsyncMock(return_value=agent)
+        agent.__aexit__ = AsyncMock(return_value=False)
+        agent.run = AsyncMock(return_value=run_results[len(calls)])
+        calls.append(kwargs.get("agent_name"))
+        return agent
+
+    return MagicMock(side_effect=_make), calls
+
+
+@pytest.mark.asyncio
+async def test_run_foundry_chat_with_routing_executes_subagent():
+    """When the chat agent routes to product_agent, the sub-agent text is returned (stripped)."""
+    from app.utils import foundry_agent_utils
+
+    chat_result = _function_call_result("product_agent", '{"task": "blue paint"}')
+    sub_result = SimpleNamespace(text="Cloud Drift, $59.5\u30104:0\u2020source\u3011")
+    factory, calls = _foundry_agent_factory([chat_result, sub_result])
+
+    mock_foundry_module = MagicMock()
+    mock_foundry_module.FoundryAgent = factory
+
+    with patch.dict(sys.modules, {"agent_framework.foundry": mock_foundry_module}):
+        result = await foundry_agent_utils._run_foundry_chat_with_routing(
+            foundry_endpoint="https://foundry.test",
+            chat_agent_name="chat-agent",
+            product_agent_name="product-agent",
+            policy_agent_name="policy-agent",
+            question="show me blue paint",
+            credential=AsyncMock(),
+        )
+
+    assert result == "Cloud Drift, $59.5"
+    assert calls == ["chat-agent", "product-agent"]
+
+
+@pytest.mark.asyncio
+async def test_run_foundry_chat_with_routing_no_call_returns_chat_text():
+    """When the chat agent emits no sub-agent call, its own text is returned."""
+    from app.utils import foundry_agent_utils
+
+    chat_result = SimpleNamespace(messages=[], text="Hello, how can I help?")
+    factory, calls = _foundry_agent_factory([chat_result])
+
+    mock_foundry_module = MagicMock()
+    mock_foundry_module.FoundryAgent = factory
+
+    with patch.dict(sys.modules, {"agent_framework.foundry": mock_foundry_module}):
+        result = await foundry_agent_utils._run_foundry_chat_with_routing(
+            foundry_endpoint="https://foundry.test",
+            chat_agent_name="chat-agent",
+            product_agent_name="product-agent",
+            policy_agent_name="policy-agent",
+            question="hi",
+            credential=AsyncMock(),
+        )
+
+    assert result == "Hello, how can I help?"
+    assert calls == ["chat-agent"]


### PR DESCRIPTION
## Purpose

Fix chatbot grounding regression (route chat agent to grounded sub-agents)

Problem: On the agent-framework-foundry==1.3.0 stack, runtime tool injection (provider.get_agent(..., tools=[...as_tool()])) no longer works connected sub-agents persist as plain function-type stubs with no in-process executor. The chat agent ran tool-less and hallucinated product/policy answers instead of grounding them via Azure AI Search.

Changes:

 - 01_create_agents.py  Bake product_agent and policy_agent into the chat agent as FunctionTools at creation time (build_subagent_tool()), so the chat agent reliably emits a routing function_call. Chat instructions aligned to main's wording plus one anti-hallucination directive.
 - foundry_agent_utils.py Add a backend router (_extract_subagent_call(), _run_foundry_chat_with_routing()) that parses the chat agent's selected sub-agent + task and executes it directly; falls back to the chat agent's own text for greetings/refusals. Also strip Azure AI Search citation markers ([source]) from response text in _result_text(), replicating the cleanup main's orchestrator did implicitly.
 - chat.py _run_with_foundry_agent() now invokes the routing helper.

Result: Product and policy queries are grounded again (real SKUs/prices/images, policy details), with clean output free of stray citation markers. Validated end-to-end on rg-byocc-az3.
## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->