### PR TITLE
fix: Cosmos DB firewall block on data upload behind proxy/VPN

### DIFF
--- a/infra/scripts/agent_scripts/run_create_agents_scripts.ps1
+++ b/infra/scripts/agent_scripts/run_create_agents_scripts.ps1
@@ -89,6 +89,11 @@ function Get-DeploymentValue {
         $value = $DeploymentOutputs.$FallbackKey.value
     }
     
+    # Trim whitespace that could corrupt downstream az --scope/--ids arguments.
+    if ($value) {
+        $value = $value.Trim()
+    }
+    
     return $value
 }
 
@@ -243,6 +248,16 @@ Write-Host "Subscription ID: $azSubscriptionId"
 Write-Host "==============================================="
 Write-Host ""
 
+# Foundry may be in a different subscription (BYO), so scope role/network ops to it.
+$aifAccountResourceId = $aiFoundryResourceId -replace '/projects/.*', ''
+$aifResourceName = Split-Path -Leaf $aifAccountResourceId
+if ($aifAccountResourceId -match '/resourceGroups/([^/]+)/') {
+    $aifResourceGroup = $Matches[1]
+}
+if ($aifAccountResourceId -match '/subscriptions/([^/]+)/') {
+    $aifSubscriptionId = $Matches[1]
+}
+
 Write-Host "Getting signed in user id"
 $signed_user_id = az ad signed-in-user show --query id -o tsv
 
@@ -251,6 +266,7 @@ $role_assignment = az role assignment list `
   --role "53ca6127-db72-4b80-b1b0-d745d6d5456d" `
   --scope "$aiFoundryResourceId" `
   --assignee "$signed_user_id" `
+  --subscription "$aifSubscriptionId" `
   --query "[].roleDefinitionId" -o tsv
 
 if ([string]::IsNullOrEmpty($role_assignment)) {
@@ -259,6 +275,7 @@ if ([string]::IsNullOrEmpty($role_assignment)) {
       --assignee "$signed_user_id" `
       --role "53ca6127-db72-4b80-b1b0-d745d6d5456d" `
       --scope "$aiFoundryResourceId" `
+      --subscription "$aifSubscriptionId" `
       --output none
 
     if ($LASTEXITCODE -eq 0) {
@@ -279,19 +296,8 @@ python -m pip install --upgrade pip
 python -m pip install --quiet -r "$requirementFile"
 
 # For WAF deployments, temporarily enable public network access on AI Foundry
+# (account id/name/rg/subscription already extracted above).
 Write-Host "Checking AI Foundry network settings..."
-
-# Extract the AI Foundry account resource ID (remove /projects/... part if present)
-$aifAccountResourceId = $aiFoundryResourceId -replace '/projects/.*', ''
-$aifResourceName = Split-Path -Leaf $aifAccountResourceId
-# Extract resource group from the AI Foundry account resource ID
-if ($aifAccountResourceId -match '/resourceGroups/([^/]+)/') {
-    $aifResourceGroup = $Matches[1]
-}
-# Extract subscription ID from the AI Foundry account resource ID
-if ($aifAccountResourceId -match '/subscriptions/([^/]+)/') {
-    $aifSubscriptionId = $Matches[1]
-}
 
 # Get current public network access setting
 $originalFoundryPublicAccess = az cognitiveservices account show --name $aifResourceName --resource-group $aifResourceGroup --subscription $aifSubscriptionId --query "properties.publicNetworkAccess" -o tsv 2>$null

--- a/infra/scripts/agent_scripts/run_create_agents_scripts.ps1
+++ b/infra/scripts/agent_scripts/run_create_agents_scripts.ps1
@@ -257,6 +257,10 @@ if ($aifAccountResourceId -match '/resourceGroups/([^/]+)/') {
 if ($aifAccountResourceId -match '/subscriptions/([^/]+)/') {
     $aifSubscriptionId = $Matches[1]
 }
+if (-not $aifSubscriptionId) {
+    # Fall back to current subscription if not parseable from the resource ID.
+    $aifSubscriptionId = $azSubscriptionId
+}
 
 Write-Host "Getting signed in user id"
 $signed_user_id = az ad signed-in-user show --query id -o tsv

--- a/infra/scripts/agent_scripts/run_create_agents_scripts.sh
+++ b/infra/scripts/agent_scripts/run_create_agents_scripts.sh
@@ -73,6 +73,8 @@ extract_value() {
     if [ -z "$result" ]; then
         result=$(echo "$deploymentOutputs" | grep -i -A 3 "\"$fallback_key\"" | grep '"value"' | sed 's/.*"value": *"\([^"]*\)".*/\1/' | head -1)
     fi
+    # Trim whitespace that could corrupt downstream az --scope/--ids arguments.
+    result=$(echo "$result" | xargs)
     echo "$result"
 }
 
@@ -503,11 +505,15 @@ set -e
 
 echo "Checking if the principal has Foundry User role on the AI Foundry"
 
+# Foundry may be in a different subscription (BYO), so scope role ops to it.
+aif_subscription_id=$(echo "$aiFoundryResourceId" | sed -n 's|.*/subscriptions/\([^/]*\)/.*|\1|p')
+
 if [ "$SKIP_ROLE_ASSIGNMENT" != "true" ] && [ -n "$signed_user_id" ]; then
     role_assignment=$(MSYS_NO_PATHCONV=1 az role assignment list \
       --role "53ca6127-db72-4b80-b1b0-d745d6d5456d" \
       --scope "$aiFoundryResourceId" \
       --assignee "$signed_user_id" \
+      --subscription "$aif_subscription_id" \
       --query "[].roleDefinitionId" -o tsv)
 
     if [ -z "$role_assignment" ]; then
@@ -516,6 +522,7 @@ if [ "$SKIP_ROLE_ASSIGNMENT" != "true" ] && [ -n "$signed_user_id" ]; then
           --assignee "$signed_user_id" \
           --role "53ca6127-db72-4b80-b1b0-d745d6d5456d" \
           --scope "$aiFoundryResourceId" \
+          --subscription "$aif_subscription_id" \
           --output none
 
         if [ $? -eq 0 ]; then

--- a/infra/scripts/agent_scripts/run_create_agents_scripts.sh
+++ b/infra/scripts/agent_scripts/run_create_agents_scripts.sh
@@ -375,8 +375,7 @@ if [[ "$currentSubscriptionId" != "$azSubscriptionId" && -n "$azSubscriptionId" 
         echo "Fetching available subscriptions..."
         availableSubscriptions=$(az account list --query "[?state=='Enabled'].[name,id]" --output tsv)
         
-        # Convert to array using readarray (works with set -e, unlike read -d '')
-        readarray -t subscriptions <<< "$availableSubscriptions"
+        readarray -t subscriptions <<< "${availableSubscriptions//$'\r'/}"
         
         while true; do
             echo ""

--- a/infra/scripts/agent_scripts/run_create_agents_scripts.sh
+++ b/infra/scripts/agent_scripts/run_create_agents_scripts.sh
@@ -507,6 +507,10 @@ echo "Checking if the principal has Foundry User role on the AI Foundry"
 
 # Foundry may be in a different subscription (BYO), so scope role ops to it.
 aif_subscription_id=$(echo "$aiFoundryResourceId" | sed -n 's|.*/subscriptions/\([^/]*\)/.*|\1|p')
+if [ -z "$aif_subscription_id" ]; then
+    # Fall back to current subscription if not parseable from the resource ID.
+    aif_subscription_id="$azSubscriptionId"
+fi
 
 if [ "$SKIP_ROLE_ASSIGNMENT" != "true" ] && [ -n "$signed_user_id" ]; then
     role_assignment=$(MSYS_NO_PATHCONV=1 az role assignment list \

--- a/infra/scripts/data_scripts/run_upload_data_scripts.ps1
+++ b/infra/scripts/data_scripts/run_upload_data_scripts.ps1
@@ -450,6 +450,9 @@ if ($originalCosmosPublicAccess -eq "Enabled") {
     # Add the detected/override IP(s) to firewall rules and enable public network access.
     # Supports a comma-separated list of IPs/CIDRs via COSMOS_FIREWALL_IP.
     $cosmosIpList = @($currentIp -split ',' | ForEach-Object { $_.Trim() } | Where-Object { $_ })
+    if ($cosmosIpList.Count -eq 0) {
+        throw "Could not determine an IP to whitelist for the Cosmos DB firewall (auto-detection failed and COSMOS_FIREWALL_IP is not set). Set COSMOS_FIREWALL_IP to an explicit IP/CIDR (or comma-separated list) and re-run. Refusing to enable public access with an empty firewall rule set."
+    }
     Write-Host "Adding IP(s) to Cosmos DB firewall: $($cosmosIpList -join ', ')"
     $ipRuleJson = "[" + (($cosmosIpList | ForEach-Object { "{\`"ipAddressOrRange\`":\`"$_\`"}" }) -join ",") + "]"
     
@@ -497,7 +500,10 @@ try {
             if ($existingIps) { $ipList = @($existingIps -split "\r?\n" | Where-Object { $_ }) }
             if ($ipList -notcontains $blockedIp) { $ipList += $blockedIp }
             $retryIpRuleJson = "[" + (($ipList | ForEach-Object { "{\`"ipAddressOrRange\`":\`"$_\`"}" }) -join ",") + "]"
-            az resource update --ids $cosmos_resource_id --api-version 2021-04-15 --set "properties.ipRules=$retryIpRuleJson" --set "properties.publicNetworkAccess=Enabled" --output none 2>$null
+            $updateError = az resource update --ids $cosmos_resource_id --api-version 2021-04-15 --set "properties.ipRules=$retryIpRuleJson" --set "properties.publicNetworkAccess=Enabled" --output none 2>&1
+            if ($LASTEXITCODE -ne 0) {
+                throw "Failed to add blocked IP $blockedIp to the Cosmos DB firewall (az resource update exit code $LASTEXITCODE): $updateError"
+            }
             $cosmosAccessEnabled = $true
             Write-Host "Waiting for Cosmos DB network changes to take effect (30 seconds)..."
             Start-Sleep -Seconds 30

--- a/infra/scripts/data_scripts/run_upload_data_scripts.ps1
+++ b/infra/scripts/data_scripts/run_upload_data_scripts.ps1
@@ -496,6 +496,9 @@ try {
             $blockedIp = $ipMatch.Groups[1].Value
             Write-Host "Cosmos DB firewall blocked actual egress IP $blockedIp - adding it and retrying (attempt $attempt of $maxUploadAttempts)..."
             $existingIps = az resource show --ids $cosmos_resource_id --api-version 2021-04-15 --query "properties.ipRules[].ipAddressOrRange" -o tsv 2>$null
+            if ($LASTEXITCODE -ne 0) {
+                throw "Failed to read existing Cosmos DB firewall rules (az resource show exit code $LASTEXITCODE); aborting recovery to avoid overwriting existing rules."
+            }
             $ipList = @()
             if ($existingIps) { $ipList = @($existingIps -split "\r?\n" | Where-Object { $_ }) }
             if ($ipList -notcontains $blockedIp) { $ipList += $blockedIp }

--- a/infra/scripts/data_scripts/run_upload_data_scripts.ps1
+++ b/infra/scripts/data_scripts/run_upload_data_scripts.ps1
@@ -418,28 +418,40 @@ $originalCosmosPublicAccess = az resource show --ids $cosmos_resource_id --api-v
 Write-Host "Original Cosmos DB public access: $originalCosmosPublicAccess"
 
 $cosmosAccessEnabled = $false
-$originalCosmosIpFilter = "[]"
+# Capture existing firewall rules up front so they can be restored accurately,
+# even if IPs are added during Forbidden recovery below.
+$originalCosmosIpFilter = az resource show --ids $cosmos_resource_id --api-version 2021-04-15 --query "properties.ipRules" -o json 2>$null
+if (-not $originalCosmosIpFilter) {
+    $originalCosmosIpFilter = "[]"
+}
 
 # Only modify Cosmos DB if it's not already enabled
 if ($originalCosmosPublicAccess -eq "Enabled") {
     Write-Host "✓ Cosmos DB public access already enabled - no changes needed"
 } else {
-    Write-Host "Getting current IP address..."
-    $currentIp = (Invoke-RestMethod -Uri "https://api.ipify.org?format=text" -TimeoutSec 10)
-    Write-Host "Current IP: $currentIp"
-    
-    # Get current firewall rules
-    Write-Host "Getting current firewall configuration..."
-    $originalCosmosIpFilter = az resource show --ids $cosmos_resource_id --api-version 2021-04-15 --query "properties.ipRules" -o json 2>$null
-    if (-not $originalCosmosIpFilter) {
-        $originalCosmosIpFilter = "[]"
+    # Determine the IP to whitelist. In proxy/VPN environments the auto-detected
+    # IP can differ from the IP Cosmos actually sees, so allow an explicit override
+    # (single IP/CIDR or comma-separated list) via COSMOS_FIREWALL_IP.
+    if ($env:COSMOS_FIREWALL_IP) {
+        $currentIp = $env:COSMOS_FIREWALL_IP
+        Write-Host "Using COSMOS_FIREWALL_IP override: $currentIp"
+    } else {
+        Write-Host "Getting current IP address..."
+        try {
+            $currentIp = (Invoke-RestMethod -Uri "https://api.ipify.org?format=text" -TimeoutSec 10)
+        } catch {
+            $currentIp = ""
+        }
+        Write-Host "Current IP: $currentIp"
     }
     
     Write-Host "Cosmos DB public access is '$originalCosmosPublicAccess' - enabling access"
     
-    # Add current IP to firewall rules and enable public network access
-    Write-Host "Adding current IP ($currentIp) to Cosmos DB firewall..."
-    $ipRuleJson = "[{\`"ipAddressOrRange\`":\`"$currentIp\`"}]"
+    # Add the detected/override IP(s) to firewall rules and enable public network access.
+    # Supports a comma-separated list of IPs/CIDRs via COSMOS_FIREWALL_IP.
+    $cosmosIpList = @($currentIp -split ',' | ForEach-Object { $_.Trim() } | Where-Object { $_ })
+    Write-Host "Adding IP(s) to Cosmos DB firewall: $($cosmosIpList -join ', ')"
+    $ipRuleJson = "[" + (($cosmosIpList | ForEach-Object { "{\`"ipAddressOrRange\`":\`"$_\`"}" }) -join ",") + "]"
     
     az resource update --ids $cosmos_resource_id --api-version 2021-04-15 --set "properties.ipRules=$ipRuleJson" --set "properties.publicNetworkAccess=Enabled" --output none 2>$null
     if ($LASTEXITCODE -eq 0) {
@@ -462,11 +474,40 @@ Write-Host "=== Public network access enabled successfully ==="
 # Run the Cosmos DB upload script within try/finally to ensure network settings are restored on error
 $dataUploadFailed = $false
 try {
-    python infra/scripts/data_scripts/03_write_products_to_cosmos.py --cosmosdb_account="$cosmosdb_account"
-    if ($LASTEXITCODE -ne 0) {
-        throw "Cosmos DB upload script failed with exit code $LASTEXITCODE"
+    $cosmosUploadSuccess = $false
+    $maxUploadAttempts = 3
+    $uploadExitCode = 0
+    for ($attempt = 1; $attempt -le $maxUploadAttempts; $attempt++) {
+        $uploadOutput = & python infra/scripts/data_scripts/03_write_products_to_cosmos.py --cosmosdb_account="$cosmosdb_account" 2>&1
+        $uploadExitCode = $LASTEXITCODE
+        $uploadText = ($uploadOutput | Out-String)
+        Write-Host $uploadText
+        if ($uploadExitCode -eq 0) {
+            $cosmosUploadSuccess = $true
+            break
+        }
+        # Recover from firewall blocks using the exact IP Cosmos reports. This handles
+        # proxy/VPN egress IPs that differ from the auto-detected public IP.
+        $ipMatch = [regex]::Match($uploadText, 'originated from IP (\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})')
+        if ($ipMatch.Success -and $attempt -lt $maxUploadAttempts) {
+            $blockedIp = $ipMatch.Groups[1].Value
+            Write-Host "Cosmos DB firewall blocked actual egress IP $blockedIp - adding it and retrying (attempt $attempt of $maxUploadAttempts)..."
+            $existingIps = az resource show --ids $cosmos_resource_id --api-version 2021-04-15 --query "properties.ipRules[].ipAddressOrRange" -o tsv 2>$null
+            $ipList = @()
+            if ($existingIps) { $ipList = @($existingIps -split "\r?\n" | Where-Object { $_ }) }
+            if ($ipList -notcontains $blockedIp) { $ipList += $blockedIp }
+            $retryIpRuleJson = "[" + (($ipList | ForEach-Object { "{\`"ipAddressOrRange\`":\`"$_\`"}" }) -join ",") + "]"
+            az resource update --ids $cosmos_resource_id --api-version 2021-04-15 --set "properties.ipRules=$retryIpRuleJson" --set "properties.publicNetworkAccess=Enabled" --output none 2>$null
+            $cosmosAccessEnabled = $true
+            Write-Host "Waiting for Cosmos DB network changes to take effect (30 seconds)..."
+            Start-Sleep -Seconds 30
+        } else {
+            break
+        }
     }
-    $cosmosUploadSuccess = $true
+    if (-not $cosmosUploadSuccess) {
+        throw "Cosmos DB upload script failed with exit code $uploadExitCode"
+    }
 }
 catch {
     Write-Host "Error running Cosmos DB upload script: $_"

--- a/infra/scripts/data_scripts/run_upload_data_scripts.ps1
+++ b/infra/scripts/data_scripts/run_upload_data_scripts.ps1
@@ -421,6 +421,7 @@ $cosmosAccessEnabled = $false
 # Capture existing firewall rules up front so they can be restored accurately,
 # even if IPs are added during Forbidden recovery below.
 $originalCosmosIpFilter = az resource show --ids $cosmos_resource_id --api-version 2021-04-15 --query "properties.ipRules" -o json 2>$null
+$ipFilterReadFailed = ($LASTEXITCODE -ne 0)
 if (-not $originalCosmosIpFilter) {
     $originalCosmosIpFilter = "[]"
 }
@@ -429,6 +430,9 @@ if (-not $originalCosmosIpFilter) {
 if ($originalCosmosPublicAccess -eq "Enabled") {
     Write-Host "✓ Cosmos DB public access already enabled - no changes needed"
 } else {
+    if ($ipFilterReadFailed) {
+        throw "Failed to read existing Cosmos DB firewall rules (az resource show exit code $LASTEXITCODE); aborting before any network changes to avoid wiping them on restore."
+    }
     # Determine the IP to whitelist. In proxy/VPN environments the auto-detected
     # IP can differ from the IP Cosmos actually sees, so allow an explicit override
     # (single IP/CIDR or comma-separated list) via COSMOS_FIREWALL_IP.
@@ -505,7 +509,7 @@ try {
             $retryIpRuleJson = "[" + (($ipList | ForEach-Object { "{\`"ipAddressOrRange\`":\`"$_\`"}" }) -join ",") + "]"
             $updateError = az resource update --ids $cosmos_resource_id --api-version 2021-04-15 --set "properties.ipRules=$retryIpRuleJson" --set "properties.publicNetworkAccess=Enabled" --output none 2>&1
             if ($LASTEXITCODE -ne 0) {
-                throw "Failed to add blocked IP $blockedIp to the Cosmos DB firewall (az resource update exit code $LASTEXITCODE): $updateError"
+                throw "Failed to add blocked IP $blockedIp to the Cosmos DB firewall (az resource update exit code $LASTEXITCODE): $($updateError | Out-String)"
             }
             $cosmosAccessEnabled = $true
             Write-Host "Waiting for Cosmos DB network changes to take effect (30 seconds)..."

--- a/infra/scripts/data_scripts/run_upload_data_scripts.sh
+++ b/infra/scripts/data_scripts/run_upload_data_scripts.sh
@@ -177,23 +177,32 @@ enable_public_access() {
 				ip_rules="${ip_rules}{\"ipAddressOrRange\":\"${_ip}\"}"
 			done
 			ip_rules="${ip_rules}]"
+			if [ "$ip_rules" = "[]" ]; then
+				echo "Error: COSMOS_FIREWALL_IP is set but contains no valid IP/CIDR entries." >&2
+				echo "  Provide a single IP/CIDR or a comma-separated list and re-run." >&2
+				exit 1
+			fi
 		else
 			echo "Getting current IP address..."
 			current_ip=$(curl -s --fail --max-time 10 https://ipinfo.io/ip)
 			current_ip="$(echo "$current_ip" | tr -d '[:space:]')"
 			echo "Current IP: $current_ip"
 
-			# Validate the detected IP is a well-formed IPv4 address before using it in
-			# arithmetic/firewall rules. Behind a proxy/VPN curl may return an empty body,
-			# an error page, or an IPv6 address, which would corrupt the ip_rules JSON.
+			# Validate IPv4 (each octet 0-255); curl may return empty/error/IPv6 behind a proxy.
+			IFS='.' read -r ip1 ip2 ip3 ip4 <<< "$current_ip"
+			valid_ipv4=true
 			if ! [[ "$current_ip" =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
+				valid_ipv4=false
+			else
+				for _octet in "$ip1" "$ip2" "$ip3" "$ip4"; do
+					if [ "$_octet" -gt 255 ]; then valid_ipv4=false; break; fi
+				done
+			fi
+			if [ "$valid_ipv4" != true ]; then
 				echo "Error: Could not auto-detect a valid IPv4 public IP (got: '$current_ip')." >&2
 				echo "  Set COSMOS_FIREWALL_IP to an explicit IP/CIDR (or comma-separated list) and re-run." >&2
 				exit 1
 			fi
-
-			# Build array of individual IPs to handle NAT/proxy variations (current IP ±2)
-			IFS='.' read -r ip1 ip2 ip3 ip4 <<< "$current_ip"
 
 			echo "Adding multiple IPs to Cosmos DB firewall to handle NAT/proxy variations..."
 			echo "  Base IP: $current_ip"
@@ -702,6 +711,10 @@ while true; do
 	if [ -n "$blocked_ip" ] && [ $upload_attempt -lt $max_upload_attempts ]; then
 		echo "Cosmos DB firewall blocked actual egress IP $blocked_ip - adding it and retrying (attempt $upload_attempt of $max_upload_attempts)..."
 		existing_ips=$(MSYS_NO_PATHCONV=1 az resource show --ids "$cosmos_resource_id" --api-version 2021-04-15 --query "properties.ipRules[].ipAddressOrRange" --output tsv 2>/dev/null)
+		if [ $? -ne 0 ]; then
+			echo "Error: Failed to read existing Cosmos DB firewall rules; aborting recovery to avoid overwriting them." >&2
+			break
+		fi
 		retry_rules="["
 		while IFS= read -r _eip; do
 			[ -z "$_eip" ] && continue

--- a/infra/scripts/data_scripts/run_upload_data_scripts.sh
+++ b/infra/scripts/data_scripts/run_upload_data_scripts.sh
@@ -711,12 +711,15 @@ while true; do
 	if [ -n "$blocked_ip" ] && [ $upload_attempt -lt $max_upload_attempts ]; then
 		echo "Cosmos DB firewall blocked actual egress IP $blocked_ip - adding it and retrying (attempt $upload_attempt of $max_upload_attempts)..."
 		existing_ips=$(MSYS_NO_PATHCONV=1 az resource show --ids "$cosmos_resource_id" --api-version 2021-04-15 --query "properties.ipRules[].ipAddressOrRange" --output tsv 2>/dev/null)
-		if [ $? -ne 0 ]; then
+		existing_ips_rc=$?
+		if [ $existing_ips_rc -ne 0 ]; then
 			echo "Error: Failed to read existing Cosmos DB firewall rules; aborting recovery to avoid overwriting them." >&2
 			break
 		fi
+		existing_ips=$(printf '%s' "$existing_ips" | tr -d '\r')
 		retry_rules="["
 		while IFS= read -r _eip; do
+			_eip="$(echo "$_eip" | tr -d '[:space:]')"
 			[ -z "$_eip" ] && continue
 			if [ "$retry_rules" != "[" ]; then retry_rules="${retry_rules},"; fi
 			retry_rules="${retry_rules}{\"ipAddressOrRange\":\"${_eip}\"}"

--- a/infra/scripts/data_scripts/run_upload_data_scripts.sh
+++ b/infra/scripts/data_scripts/run_upload_data_scripts.sh
@@ -179,8 +179,18 @@ enable_public_access() {
 			ip_rules="${ip_rules}]"
 		else
 			echo "Getting current IP address..."
-			current_ip=$(curl -s https://ipinfo.io/ip)
+			current_ip=$(curl -s --fail --max-time 10 https://ipinfo.io/ip)
+			current_ip="$(echo "$current_ip" | tr -d '[:space:]')"
 			echo "Current IP: $current_ip"
+
+			# Validate the detected IP is a well-formed IPv4 address before using it in
+			# arithmetic/firewall rules. Behind a proxy/VPN curl may return an empty body,
+			# an error page, or an IPv6 address, which would corrupt the ip_rules JSON.
+			if ! [[ "$current_ip" =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
+				echo "Error: Could not auto-detect a valid IPv4 public IP (got: '$current_ip')." >&2
+				echo "  Set COSMOS_FIREWALL_IP to an explicit IP/CIDR (or comma-separated list) and re-run." >&2
+				exit 1
+			fi
 
 			# Build array of individual IPs to handle NAT/proxy variations (current IP ±2)
 			IFS='.' read -r ip1 ip2 ip3 ip4 <<< "$current_ip"
@@ -703,7 +713,12 @@ while true; do
 			retry_rules="${retry_rules}{\"ipAddressOrRange\":\"${blocked_ip}\"}"
 		fi
 		retry_rules="${retry_rules}]"
-		MSYS_NO_PATHCONV=1 az resource update --ids "$cosmos_resource_id" --api-version 2021-04-15 --set "properties.ipRules=$retry_rules" --set "properties.publicNetworkAccess=Enabled" --output none 2>/dev/null
+		update_err=$(MSYS_NO_PATHCONV=1 az resource update --ids "$cosmos_resource_id" --api-version 2021-04-15 --set "properties.ipRules=$retry_rules" --set "properties.publicNetworkAccess=Enabled" --output none 2>&1)
+		if [ $? -ne 0 ]; then
+			echo "Error: Failed to add blocked IP $blocked_ip to the Cosmos DB firewall. Aborting retries." >&2
+			echo "$update_err" >&2
+			break
+		fi
 		echo "Waiting for Cosmos DB network changes to take effect (30 seconds)..."
 		sleep 30
 		upload_attempt=$((upload_attempt + 1))

--- a/infra/scripts/data_scripts/run_upload_data_scripts.sh
+++ b/infra/scripts/data_scripts/run_upload_data_scripts.sh
@@ -152,39 +152,57 @@ enable_public_access() {
 	if [ "$original_cosmos_public_access" = "Enabled" ]; then
 		echo "✓ Cosmos DB public access already enabled - no changes needed"
 	else
-		echo "Getting current IP address..."
-		current_ip=$(curl -s https://ipinfo.io/ip)
-		echo "Current IP: $current_ip"
-        # Get current firewall rules and public network access setting
-        echo "Getting current firewall configuration..."
-        original_cosmos_ip_filter=$(MSYS_NO_PATHCONV=1 az resource show \
-            --ids "$cosmos_resource_id" \
-            --api-version 2021-04-15 \
-            --query "properties.ipRules" \
-            --output json 2>/dev/null || echo "[]")
+		# Capture current firewall rules so they can be restored later.
+		echo "Getting current firewall configuration..."
+		original_cosmos_ip_filter=$(MSYS_NO_PATHCONV=1 az resource show \
+			--ids "$cosmos_resource_id" \
+			--api-version 2021-04-15 \
+			--query "properties.ipRules" \
+			--output json 2>/dev/null || echo "[]")
 
 		echo "Cosmos DB public access is '$original_cosmos_public_access' - enabling access"
-		
-		# Build array of individual IPs to handle NAT/proxy variations (current IP ±2)
-		IFS='.' read -r ip1 ip2 ip3 ip4 <<< "$current_ip"
-		
-		echo "Adding multiple IPs to Cosmos DB firewall to handle NAT/proxy variations..."
-		echo "  Base IP: $current_ip"
-		
-		# Build JSON array with current IP and ±2 range
-		ip_rules="["
-		for offset in -2 -1 0 1 2; do
-			new_octet=$((ip4 + offset))
-			if [ $new_octet -ge 0 ] && [ $new_octet -le 255 ]; then
+
+		if [ -n "$COSMOS_FIREWALL_IP" ]; then
+			# Explicit override for proxy/VPN environments where the auto-detected IP
+			# differs from the IP Cosmos actually sees. Comma-separated IPs/CIDRs.
+			echo "Using COSMOS_FIREWALL_IP override: $COSMOS_FIREWALL_IP"
+			ip_rules="["
+			IFS=',' read -ra _override_ips <<< "$COSMOS_FIREWALL_IP"
+			for _ip in "${_override_ips[@]}"; do
+				_ip="$(echo "$_ip" | xargs)"
+				[ -z "$_ip" ] && continue
 				if [ "$ip_rules" != "[" ]; then
 					ip_rules="${ip_rules},"
 				fi
-				ip_rules="${ip_rules}{\"ipAddressOrRange\":\"${ip1}.${ip2}.${ip3}.${new_octet}\"}"
-			fi
-		done
-		ip_rules="${ip_rules}]"
-		
-		echo "  Adding 5 IPs: ${ip1}.${ip2}.${ip3}.$((ip4-2)) to ${ip1}.${ip2}.${ip3}.$((ip4+2))"
+				ip_rules="${ip_rules}{\"ipAddressOrRange\":\"${_ip}\"}"
+			done
+			ip_rules="${ip_rules}]"
+		else
+			echo "Getting current IP address..."
+			current_ip=$(curl -s https://ipinfo.io/ip)
+			echo "Current IP: $current_ip"
+
+			# Build array of individual IPs to handle NAT/proxy variations (current IP ±2)
+			IFS='.' read -r ip1 ip2 ip3 ip4 <<< "$current_ip"
+
+			echo "Adding multiple IPs to Cosmos DB firewall to handle NAT/proxy variations..."
+			echo "  Base IP: $current_ip"
+
+			# Build JSON array with current IP and ±2 range
+			ip_rules="["
+			for offset in -2 -1 0 1 2; do
+				new_octet=$((ip4 + offset))
+				if [ $new_octet -ge 0 ] && [ $new_octet -le 255 ]; then
+					if [ "$ip_rules" != "[" ]; then
+						ip_rules="${ip_rules},"
+					fi
+					ip_rules="${ip_rules}{\"ipAddressOrRange\":\"${ip1}.${ip2}.${ip3}.${new_octet}\"}"
+				fi
+			done
+			ip_rules="${ip_rules}]"
+
+			echo "  Adding 5 IPs: ${ip1}.${ip2}.${ip3}.$((ip4-2)) to ${ip1}.${ip2}.${ip3}.$((ip4+2))"
+		fi
 		
 		# Add multiple IPs to firewall rules and enable public network access
 		if MSYS_NO_PATHCONV=1 az resource update \
@@ -657,6 +675,46 @@ fi
 # python pip install -r infra/scripts/data_scripts/requirements.txt --quiet
 python infra/scripts/data_scripts/01_create_products_search_index.py --ai_search_endpoint="$ai_search_endpoint" --azure_openai_endpoint="$azure_openai_endpoint" --embedding_model_name="$embedding_model_name"
 python infra/scripts/data_scripts/02_create_policies_search_index.py --ai_search_endpoint="$ai_search_endpoint" --azure_openai_endpoint="$azure_openai_endpoint" --embedding_model_name="$embedding_model_name"
-python infra/scripts/data_scripts/03_write_products_to_cosmos.py --cosmosdb_account="$cosmosdb_account"
+# Run the Cosmos upload with retry-on-Forbidden recovery. In proxy/VPN environments
+# the egress IP Cosmos sees can differ from the auto-detected IP; on a firewall block
+# we extract the exact IP Cosmos reports, add it to the firewall, and retry.
+set +e
+max_upload_attempts=3
+upload_attempt=1
+while true; do
+	upload_output=$(python infra/scripts/data_scripts/03_write_products_to_cosmos.py --cosmosdb_account="$cosmosdb_account" 2>&1)
+	upload_rc=$?
+	echo "$upload_output"
+	if [ $upload_rc -eq 0 ]; then
+		break
+	fi
+	blocked_ip=$(echo "$upload_output" | grep -oE 'originated from IP [0-9]+\.[0-9]+\.[0-9]+\.[0-9]+' | grep -oE '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+' | head -n1)
+	if [ -n "$blocked_ip" ] && [ $upload_attempt -lt $max_upload_attempts ]; then
+		echo "Cosmos DB firewall blocked actual egress IP $blocked_ip - adding it and retrying (attempt $upload_attempt of $max_upload_attempts)..."
+		existing_ips=$(MSYS_NO_PATHCONV=1 az resource show --ids "$cosmos_resource_id" --api-version 2021-04-15 --query "properties.ipRules[].ipAddressOrRange" --output tsv 2>/dev/null)
+		retry_rules="["
+		while IFS= read -r _eip; do
+			[ -z "$_eip" ] && continue
+			if [ "$retry_rules" != "[" ]; then retry_rules="${retry_rules},"; fi
+			retry_rules="${retry_rules}{\"ipAddressOrRange\":\"${_eip}\"}"
+		done <<< "$existing_ips"
+		if ! echo "$existing_ips" | grep -qx "$blocked_ip"; then
+			if [ "$retry_rules" != "[" ]; then retry_rules="${retry_rules},"; fi
+			retry_rules="${retry_rules}{\"ipAddressOrRange\":\"${blocked_ip}\"}"
+		fi
+		retry_rules="${retry_rules}]"
+		MSYS_NO_PATHCONV=1 az resource update --ids "$cosmos_resource_id" --api-version 2021-04-15 --set "properties.ipRules=$retry_rules" --set "properties.publicNetworkAccess=Enabled" --output none 2>/dev/null
+		echo "Waiting for Cosmos DB network changes to take effect (30 seconds)..."
+		sleep 30
+		upload_attempt=$((upload_attempt + 1))
+		continue
+	fi
+	echo "Error: Cosmos DB upload failed (exit code $upload_rc) and could not be recovered."
+	break
+done
+set -e
+if [ $upload_rc -ne 0 ]; then
+	exit $upload_rc
+fi
 
 echo "Network access will be restored to original settings..."

--- a/infra/scripts/data_scripts/run_upload_data_scripts.sh
+++ b/infra/scripts/data_scripts/run_upload_data_scripts.sh
@@ -152,13 +152,19 @@ enable_public_access() {
 	if [ "$original_cosmos_public_access" = "Enabled" ]; then
 		echo "✓ Cosmos DB public access already enabled - no changes needed"
 	else
-		# Capture current firewall rules so they can be restored later.
+		# Abort if the read fails so restore never wipes rules with an empty set.
 		echo "Getting current firewall configuration..."
 		original_cosmos_ip_filter=$(MSYS_NO_PATHCONV=1 az resource show \
 			--ids "$cosmos_resource_id" \
 			--api-version 2021-04-15 \
 			--query "properties.ipRules" \
-			--output json 2>/dev/null || echo "[]")
+			--output json 2>/dev/null)
+		if [ $? -ne 0 ]; then
+			echo "Error: Failed to read existing Cosmos DB firewall rules; aborting before any network changes to avoid wiping them on restore." >&2
+			# No changes were made yet, so skip the restore trap (it would write ipRules=[]).
+			trap - EXIT INT TERM
+			exit 1
+		fi
 
 		echo "Cosmos DB public access is '$original_cosmos_public_access' - enabling access"
 
@@ -166,6 +172,7 @@ enable_public_access() {
 			# Explicit override for proxy/VPN environments where the auto-detected IP
 			# differs from the IP Cosmos actually sees. Comma-separated IPs/CIDRs.
 			echo "Using COSMOS_FIREWALL_IP override: $COSMOS_FIREWALL_IP"
+			current_ip="$COSMOS_FIREWALL_IP"
 			ip_rules="["
 			IFS=',' read -ra _override_ips <<< "$COSMOS_FIREWALL_IP"
 			for _ip in "${_override_ips[@]}"; do
@@ -724,7 +731,7 @@ while true; do
 			if [ "$retry_rules" != "[" ]; then retry_rules="${retry_rules},"; fi
 			retry_rules="${retry_rules}{\"ipAddressOrRange\":\"${_eip}\"}"
 		done <<< "$existing_ips"
-		if ! echo "$existing_ips" | grep -qx "$blocked_ip"; then
+		if ! echo "$existing_ips" | grep -Fqx "$blocked_ip"; then
 			if [ "$retry_rules" != "[" ]; then retry_rules="${retry_rules},"; fi
 			retry_rules="${retry_rules}{\"ipAddressOrRange\":\"${blocked_ip}\"}"
 		fi


### PR DESCRIPTION
## Purpose
Auto-detected public IP (via ipify/ipinfo) can differ from the IP Cosmos actually sees behind a corporate proxy, causing a Forbidden firewall error.

- Retry the Cosmos upload on Forbidden: extract the real egress IP from the Cosmos error message, add it to the firewall, and retry (up to 3 attempts).
- Support COSMOS_FIREWALL_IP override (single IP/CIDR or comma-separated list).
- Capture original ipRules up front so restore stays accurate after recovery.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
Re-ran the PowerShell script end-to-end: 16 products upserted to Cosmos DB, and public network access restored to Disabled

## What to Check
Verify that the following are valid
Run the PowerShell script end-to-end: 16 products upserted to Cosmos DB, and public network access restored to Disabled

## Other Information
 Problem

  run_upload_data_scripts opens the Cosmos DB firewall temporarily by detecting the machine's public IP (via ipify/ipinfo) and whitelisting it. Behind a corporate proxy/VPN, the IP used for that lookup differs from the IP Cosmos actually sees, so the upload fails with Forbidden: Request originated from IP ... blocked by firewall.

  Fix

   - Retry-on-Forbidden: on a firewall block, extract the real egress IP from the Cosmos error message, add it to the firewall, and retry (up to 3 attempts).
   - COSMOS_FIREWALL_IP override: optionally whitelist a specific IP/CIDR (comma-separated supported) for locked-down environments.
   - Capture original ipRules up front so network settings restore accurately after recovery.
   - Applied to both run_upload_data_scripts.ps1 and .sh for parity.