### PR TITLE
ci: pin third-party GitHub Actions to verified release SHAs

### DIFF
--- a/.github/workflows/broken-links-checker.yml
+++ b/.github/workflows/broken-links-checker.yml
@@ -20,21 +20,28 @@ jobs:
         with:
           fetch-depth: 0
 
-      # For PR : Get only changed markdown files
+      # For PR : Get only changed markdown files (using built-in git)
       - name: Get changed markdown files (PR only)
         id: changed-markdown-files
         if: github.event_name == 'pull_request'
-        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
-        with:
-          files: |
-            **/*.md
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          changed_files=$(git diff --name-only --diff-filter=ACMR "$BASE_SHA" "$HEAD_SHA" -- '*.md' | tr '\n' ' ' | sed 's/ *$//')
+          if [ -n "$changed_files" ]; then
+            echo "any_changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "any_changed=false" >> "$GITHUB_OUTPUT"
+          fi
+          echo "all_changed_files=$changed_files" >> "$GITHUB_OUTPUT"
 
 
       # For PR: Check broken links only in changed files
       - name: Check Broken Links in Changed Markdown Files
         id: lychee-check-pr
         if: github.event_name == 'pull_request' && steps.changed-markdown-files.outputs.any_changed == 'true'
-        uses: lycheeverse/lychee-action@v2.8.0
+        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
         with:
           args: >
             --verbose --no-progress --exclude '^(https?|mailto):'
@@ -47,7 +54,7 @@ jobs:
       - name: Check Broken Links in All Markdown Files in Entire Repo (Manual Trigger)
         id: lychee-check-manual
         if: github.event_name == 'workflow_dispatch'
-        uses: lycheeverse/lychee-action@v2.8.0
+        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
         with:
           args: >
             --verbose --no-progress --exclude '^(https?|mailto):'

--- a/.github/workflows/pr-title-checker.yml
+++ b/.github/workflows/pr-title-checker.yml
@@ -17,6 +17,6 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event_name != 'merge_group' }}
     steps:
-      - uses: amannn/action-semantic-pull-request@v6
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -77,7 +77,7 @@ jobs:
           always() &&
           github.event_name == 'pull_request' &&
           github.event.pull_request.head.repo.fork == false
-        uses: MishaKav/pytest-coverage-comment@dd5b80bde6d16941f336518e92929e89069d8451  # v1.7.2
+        uses: MishaKav/pytest-coverage-comment@e48ae95fa406cefacc7fbdd79949122795569961 # v1.8.0
         with:
           pytest-xml-coverage-path: src/coverage.xml
           junitxml-path: src/coverage-junit.xml


### PR DESCRIPTION
## Purpose
Harden CI/CD against supply-chain attacks by pinning third-party actions to verified release commit SHAs.

* Replace `tj-actions/changed-files`  in `broken-links-checker.yml` with a built-in `git diff` step. The new step detects changed markdown files between the PR base and head SHAs and preserves the `any_changed` / `all_changed_files` outputs consumed by the lychee step — zero third-party dependency.
* Pin third-party actions to their latest verified release SHAs (mutable tags can be silently repointed to malicious code):
  * `lycheeverse/lychee-action` → `8646ba3` (v2.8.0)
  * `amannn/action-semantic-pull-request` → `48f2562` (v6.1.1)
  * `MishaKav/pytest-coverage-comment` → `e48ae95` (v1.8.0)

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## How to Test
* Get the code

```
git clone https://github.com/microsoft/customer-chatbot-solution-accelerator
cd customer-chatbot-solution-accelerator
git checkout ci/pin-actions-and-git-diff
```

* Test the code

```
# Open a PR that adds/modifies a markdown file containing a broken relative link.
# The "Broken Link Checker" workflow should:
#   - detect the changed markdown file via the new git diff step (all_changed_files)
#   - fail on the broken link, pass when the link is valid
```

(Validated on a throwaway PR: the git-diff step listed the changed file and lychee failed only on the broken link, exit code 2.)

## What to Check
Verify that the following are valid
* No workflow references `tj-actions/changed-files`.
* Every third-party action uses a full commit SHA with a trailing version comment.
* Pinned SHAs resolve to the latest release tags (v2.8.0 / v6.1.1 / v1.8.0).
* Affected jobs retain least-privilege `permissions:` (`pull-requests: read` for pr-title-checker, `pull-requests: write` for tests).
* Broken-link checker still detects changed markdown and fails on broken links.

## Other Information
Changed files:
* `.github/workflows/broken-links-checker.yml`
* `.github/workflows/pr-title-checker.yml`
* `.github/workflows/tests.yaml`
