### PR TITLE
fix: Add ACR public access management functions to build scripts

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -616,7 +616,7 @@ var dnsZoneIndex = {
   cosmosDb: 3
   search: 4
   webApp: 5
-  containerRegistry: 4
+  containerRegistry: 6
 }
 
 // List of DNS zone indices that correspond to AI-related services.

--- a/infra/scripts/build_push_images.ps1
+++ b/infra/scripts/build_push_images.ps1
@@ -199,8 +199,17 @@ function Enable-AcrPublicAccess {
     param([string]$Name)
     Write-Host "Checking ACR public network access for '$Name'..." -ForegroundColor DarkGray
 
-    $script:OriginalAcrPublicAccess  = (az acr show --name $Name --query "publicNetworkAccess"          -o tsv 2>$null).Trim()
-    $script:OriginalAcrDefaultAction = (az acr show --name $Name --query "networkRuleSet.defaultAction" -o tsv 2>$null).Trim()
+    $rawPublicAccess = az acr show --name $Name --query "publicNetworkAccess" -o tsv 2>$null
+    if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($rawPublicAccess)) {
+        throw "Failed to read ACR public network access for '$Name' (exit $LASTEXITCODE). Ensure the registry exists and you have sufficient permissions."
+    }
+    $script:OriginalAcrPublicAccess = $rawPublicAccess.Trim()
+
+    $rawDefaultAction = az acr show --name $Name --query "networkRuleSet.defaultAction" -o tsv 2>$null
+    if ($LASTEXITCODE -ne 0) {
+        throw "Failed to read ACR network rule set for '$Name' (exit $LASTEXITCODE)."
+    }
+    $script:OriginalAcrDefaultAction = if ([string]::IsNullOrWhiteSpace($rawDefaultAction)) { '' } else { $rawDefaultAction.Trim() }
     Write-Host "  Current: publicNetworkAccess=$($script:OriginalAcrPublicAccess)  defaultAction=$($script:OriginalAcrDefaultAction)" -ForegroundColor DarkGray
 
     if ($script:OriginalAcrPublicAccess -ne 'Enabled') {

--- a/infra/scripts/build_push_images.ps1
+++ b/infra/scripts/build_push_images.ps1
@@ -189,6 +189,68 @@ function Set-WebAppContainer {
 }
 
 # ---------------------------------------------------------------------------
+# ACR public-access helpers
+# ---------------------------------------------------------------------------
+$script:OriginalAcrPublicAccess  = $null
+$script:OriginalAcrDefaultAction = $null
+$script:AcrAccessModified        = $false
+
+function Enable-AcrPublicAccess {
+    param([string]$Name)
+    Write-Host "Checking ACR public network access for '$Name'..." -ForegroundColor DarkGray
+
+    $script:OriginalAcrPublicAccess  = (az acr show --name $Name --query "publicNetworkAccess"          -o tsv 2>$null).Trim()
+    $script:OriginalAcrDefaultAction = (az acr show --name $Name --query "networkRuleSet.defaultAction" -o tsv 2>$null).Trim()
+    Write-Host "  Current: publicNetworkAccess=$($script:OriginalAcrPublicAccess)  defaultAction=$($script:OriginalAcrDefaultAction)" -ForegroundColor DarkGray
+
+    if ($script:OriginalAcrPublicAccess -ne 'Enabled') {
+        Write-Host "  Enabling ACR public network access..." -ForegroundColor Cyan
+        az acr update --name $Name --public-network-enabled true --only-show-errors | Out-Null
+        if ($LASTEXITCODE -ne 0) { throw "Failed to enable public network access for ACR '$Name'." }
+        $script:AcrAccessModified = $true
+    }
+
+    if ($script:OriginalAcrDefaultAction -eq 'Deny') {
+        Write-Host "  Setting ACR network default action to Allow..." -ForegroundColor Cyan
+        az acr update --name $Name --default-action Allow --only-show-errors | Out-Null
+        if ($LASTEXITCODE -ne 0) { throw "Failed to set default network action for ACR '$Name'." }
+        $script:AcrAccessModified = $true
+    }
+
+    if ($script:AcrAccessModified) {
+        Write-Host "  ACR network access updated. Waiting 15 s for changes to propagate..." -ForegroundColor DarkGray
+        Start-Sleep -Seconds 15
+    } else {
+        Write-Host "  ACR public access already open - no changes needed." -ForegroundColor DarkGray
+    }
+}
+
+function Restore-AcrAccess {
+    param([string]$Name)
+    Write-Host ""
+    Write-Host "=== Restoring original ACR network settings ===" -ForegroundColor DarkGray
+    if (-not $script:AcrAccessModified) {
+        Write-Host "  ACR unchanged - no restoration needed." -ForegroundColor DarkGray
+        return
+    }
+    Write-Host "  Restoring ACR '$Name' to original settings..." -ForegroundColor Cyan
+    $updateArgs = @('acr', 'update', '--name', $Name, '--only-show-errors')
+    if ($script:OriginalAcrPublicAccess -ne 'Enabled') {
+        $updateArgs += @('--public-network-enabled', 'false')
+    }
+    if ($script:OriginalAcrDefaultAction -eq 'Deny') {
+        $updateArgs += @('--default-action', 'Deny')
+    }
+    az @updateArgs | Out-Null
+    if ($LASTEXITCODE -eq 0) {
+        Write-Host "  ACR settings restored (publicNetworkAccess=$($script:OriginalAcrPublicAccess), defaultAction=$($script:OriginalAcrDefaultAction))." -ForegroundColor Green
+    } else {
+        Write-Host "  WARNING: Failed to restore ACR network settings for '$Name'. Please restore manually." -ForegroundColor Yellow
+        Write-Host "    Expected: publicNetworkAccess=$($script:OriginalAcrPublicAccess)  defaultAction=$($script:OriginalAcrDefaultAction)" -ForegroundColor Yellow
+    }
+}
+
+# ---------------------------------------------------------------------------
 # Pre-flight checks
 # ---------------------------------------------------------------------------
 if (-not (Test-CommandAvailable 'az')) {
@@ -243,25 +305,32 @@ Write-Host ""
 # ---------------------------------------------------------------------------
 # Build & deploy
 # ---------------------------------------------------------------------------
-if (-not $SkipBackend) {
-    if (-not (Test-Path (Join-Path $backendCtx 'Dockerfile'))) {
-        throw "Backend Dockerfile not found at $backendCtx/Dockerfile"
-    }
-    Invoke-AcrBuild -Registry $AcrName -Image $BackendImage -Tag $ImageTag -Context $backendCtx
-    Set-WebAppContainer -Rg $ResourceGroup -AppName $BackendAppName -AcrLoginServer $acrLoginServer -Image $BackendImage -Tag $ImageTag
-} else {
-    Write-Host "Skipping backend (SkipBackend)." -ForegroundColor Yellow
-}
+try {
+    Enable-AcrPublicAccess -Name $AcrName
 
-if (-not $SkipFrontend) {
-    if (-not (Test-Path (Join-Path $frontendCtx 'Dockerfile'))) {
-        throw "Frontend Dockerfile not found at $frontendCtx/Dockerfile"
+    if (-not $SkipBackend) {
+        if (-not (Test-Path (Join-Path $backendCtx 'Dockerfile'))) {
+            throw "Backend Dockerfile not found at $backendCtx/Dockerfile"
+        }
+        Invoke-AcrBuild -Registry $AcrName -Image $BackendImage -Tag $ImageTag -Context $backendCtx
+        Set-WebAppContainer -Rg $ResourceGroup -AppName $BackendAppName -AcrLoginServer $acrLoginServer -Image $BackendImage -Tag $ImageTag
+    } else {
+        Write-Host "Skipping backend (SkipBackend)." -ForegroundColor Yellow
     }
-    Invoke-AcrBuild -Registry $AcrName -Image $FrontendImage -Tag $ImageTag -Context $frontendCtx
-    Set-WebAppContainer -Rg $ResourceGroup -AppName $FrontendAppName -AcrLoginServer $acrLoginServer -Image $FrontendImage -Tag $ImageTag
-} else {
-    Write-Host "Skipping frontend (SkipFrontend)." -ForegroundColor Yellow
-}
 
-Write-Host ""
-Write-Host "Done. Images published with tag '$ImageTag'." -ForegroundColor Green
+    if (-not $SkipFrontend) {
+        if (-not (Test-Path (Join-Path $frontendCtx 'Dockerfile'))) {
+            throw "Frontend Dockerfile not found at $frontendCtx/Dockerfile"
+        }
+        Invoke-AcrBuild -Registry $AcrName -Image $FrontendImage -Tag $ImageTag -Context $frontendCtx
+        Set-WebAppContainer -Rg $ResourceGroup -AppName $FrontendAppName -AcrLoginServer $acrLoginServer -Image $FrontendImage -Tag $ImageTag
+    } else {
+        Write-Host "Skipping frontend (SkipFrontend)." -ForegroundColor Yellow
+    }
+
+    Write-Host ""
+    Write-Host "Done. Images published with tag '$ImageTag'." -ForegroundColor Green
+}
+finally {
+    Restore-AcrAccess -Name $AcrName
+}

--- a/infra/scripts/build_push_images.sh
+++ b/infra/scripts/build_push_images.sh
@@ -37,6 +37,11 @@ SKIP_BACKEND=false
 SKIP_FRONTEND=false
 SHOW_LOGS=false
 
+# ACR public-access state (populated by enable_acr_public_access)
+ORIGINAL_ACR_PUBLIC_ACCESS=""
+ORIGINAL_ACR_DEFAULT_ACTION=""
+ACR_ACCESS_MODIFIED=false
+
 usage() {
     sed -n '2,25p' "$0"
     exit "${1:-0}"
@@ -192,6 +197,64 @@ update_webapp() {
     az webapp restart --name "$app" --resource-group "$rg" --only-show-errors >/dev/null
 }
 
+enable_acr_public_access() {
+    local name="$1"
+    echo "Checking ACR public network access for '$name'..."
+
+    ORIGINAL_ACR_PUBLIC_ACCESS="$(az acr show --name "$name" --query "publicNetworkAccess"          -o tsv 2>/dev/null || true)"
+    ORIGINAL_ACR_DEFAULT_ACTION="$(az acr show --name "$name" --query "networkRuleSet.defaultAction" -o tsv 2>/dev/null || true)"
+    echo "  Current: publicNetworkAccess=${ORIGINAL_ACR_PUBLIC_ACCESS}  defaultAction=${ORIGINAL_ACR_DEFAULT_ACTION}"
+
+    if [[ "$ORIGINAL_ACR_PUBLIC_ACCESS" != "Enabled" ]]; then
+        echo "  Enabling ACR public network access..."
+        az acr update --name "$name" --public-network-enabled true --only-show-errors >/dev/null
+        ACR_ACCESS_MODIFIED=true
+    fi
+
+    if [[ "$ORIGINAL_ACR_DEFAULT_ACTION" == "Deny" ]]; then
+        echo "  Setting ACR network default action to Allow..."
+        az acr update --name "$name" --default-action Allow --only-show-errors >/dev/null
+        ACR_ACCESS_MODIFIED=true
+    fi
+
+    if $ACR_ACCESS_MODIFIED; then
+        echo "  ACR network access updated. Waiting 15 s for changes to propagate..."
+        sleep 15
+    else
+        echo "  ACR public access already open - no changes needed."
+    fi
+}
+
+restore_acr_access() {
+    local name="$1"
+    echo ""
+    echo "=== Restoring original ACR network settings ==="
+    if ! $ACR_ACCESS_MODIFIED; then
+        echo "  ACR unchanged - no restoration needed."
+        return 0
+    fi
+    echo "  Restoring ACR '$name' to original settings..."
+    local update_args=("acr" "update" "--name" "$name" "--only-show-errors")
+    if [[ "$ORIGINAL_ACR_PUBLIC_ACCESS" != "Enabled" ]]; then
+        update_args+=("--public-network-enabled" "false")
+    fi
+    if [[ "$ORIGINAL_ACR_DEFAULT_ACTION" == "Deny" ]]; then
+        update_args+=("--default-action" "Deny")
+    fi
+    if az "${update_args[@]}" >/dev/null 2>&1; then
+        echo "  \u2713 ACR settings restored (publicNetworkAccess=${ORIGINAL_ACR_PUBLIC_ACCESS}, defaultAction=${ORIGINAL_ACR_DEFAULT_ACTION})."
+    else
+        echo "  WARNING: Failed to restore ACR network settings for '$name'. Please restore manually."
+        echo "    Expected: publicNetworkAccess=${ORIGINAL_ACR_PUBLIC_ACCESS}  defaultAction=${ORIGINAL_ACR_DEFAULT_ACTION}"
+    fi
+}
+
+cleanup_on_exit() {
+    local exit_code=$?
+    restore_acr_access "$ACR_NAME"
+    exit $exit_code
+}
+
 # ---------------------------------------------------------------------------
 # Resolve inputs
 # ---------------------------------------------------------------------------
@@ -235,6 +298,10 @@ Configuration
   Frontend app   : $FRONTEND_APP
   Image tag      : $IMAGE_TAG
 EOF
+
+trap cleanup_on_exit EXIT INT TERM
+
+enable_acr_public_access "$ACR_NAME"
 
 # ---------------------------------------------------------------------------
 # Build & deploy

--- a/infra/scripts/build_push_images.sh
+++ b/infra/scripts/build_push_images.sh
@@ -201,8 +201,22 @@ enable_acr_public_access() {
     local name="$1"
     echo "Checking ACR public network access for '$name'..."
 
-    ORIGINAL_ACR_PUBLIC_ACCESS="$(az acr show --name "$name" --query "publicNetworkAccess"          -o tsv 2>/dev/null || true)"
-    ORIGINAL_ACR_DEFAULT_ACTION="$(az acr show --name "$name" --query "networkRuleSet.defaultAction" -o tsv 2>/dev/null || true)"
+    local raw_public_access raw_default_action
+    raw_public_access="$(az acr show --name "$name" --query "publicNetworkAccess" -o tsv 2>/dev/null)" || {
+        echo "ERROR: Failed to read ACR public network access for '$name'. Ensure the registry exists and you have sufficient permissions." >&2
+        return 1
+    }
+    if [[ -z "$raw_public_access" ]]; then
+        echo "ERROR: ACR '$name' returned no publicNetworkAccess value. Ensure the registry name is correct." >&2
+        return 1
+    fi
+    ORIGINAL_ACR_PUBLIC_ACCESS="$raw_public_access"
+
+    raw_default_action="$(az acr show --name "$name" --query "networkRuleSet.defaultAction" -o tsv 2>/dev/null)" || {
+        echo "ERROR: Failed to read ACR network rule set for '$name'." >&2
+        return 1
+    }
+    ORIGINAL_ACR_DEFAULT_ACTION="$raw_default_action"
     echo "  Current: publicNetworkAccess=${ORIGINAL_ACR_PUBLIC_ACCESS}  defaultAction=${ORIGINAL_ACR_DEFAULT_ACTION}"
 
     if [[ "$ORIGINAL_ACR_PUBLIC_ACCESS" != "Enabled" ]]; then
@@ -250,9 +264,7 @@ restore_acr_access() {
 }
 
 cleanup_on_exit() {
-    local exit_code=$?
     restore_acr_access "$ACR_NAME"
-    exit $exit_code
 }
 
 # ---------------------------------------------------------------------------
@@ -299,7 +311,9 @@ Configuration
   Image tag      : $IMAGE_TAG
 EOF
 
-trap cleanup_on_exit EXIT INT TERM
+trap cleanup_on_exit EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
 
 enable_acr_public_access "$ACR_NAME"
 


### PR DESCRIPTION
This pull request adds robust handling for Azure Container Registry (ACR) public network access in both the PowerShell (`build_push_images.ps1`) and Bash (`build_push_images.sh`) image build/deploy scripts. The scripts now ensure that ACR public access is enabled before building and pushing images, and then restore the original ACR network settings afterward, even if an error occurs. This helps prevent accidental exposure or misconfiguration of ACR network rules during CI/CD operations.

Key changes:

**ACR Public Access Management:**

* Added `Enable-AcrPublicAccess` and `Restore-AcrAccess` functions to `build_push_images.ps1` to manage ACR public network access and network rule settings before and after the script runs. The script records the original state and restores it at the end.
* Added `enable_acr_public_access`, `restore_acr_access`, and `cleanup_on_exit` functions to `build_push_images.sh` to provide equivalent functionality in Bash, including trapping script exit to ensure restoration. [[1]](diffhunk://#diff-56deae02b53dc2c3bba3074fdd1f37e4618675adedbf90951228026cba82bc66R40-R44) [[2]](diffhunk://#diff-56deae02b53dc2c3bba3074fdd1f37e4618675adedbf90951228026cba82bc66R200-R257)

**Script Execution Flow:**

* Updated both scripts to call the ACR public access enabling function before image build/push, and to restore the original settings afterward (using `try/finally` in PowerShell, and a `trap` in Bash). This ensures cleanup even if the script fails or is interrupted. [[1]](diffhunk://#diff-bba1ef145be350d9476b61c90014e56c23f5cb35a28956624f44d207fe74741aR308-R310) [[2]](diffhunk://#diff-bba1ef145be350d9476b61c90014e56c23f5cb35a28956624f44d207fe74741aR333-R336) [[3]](diffhunk://#diff-56deae02b53dc2c3bba3074fdd1f37e4618675adedbf90951228026cba82bc66R302-R305)## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* ...

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [ ] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->