### PR TITLE
feat: Restrict backend APIs to private access with reverse proxy

### DIFF
--- a/chat-app/frontend/Dockerfile
+++ b/chat-app/frontend/Dockerfile
@@ -21,6 +21,10 @@ FROM mcr.microsoft.com/azurelinux/base/nginx:1.28.3-8-azl3.0.20260722
 
 COPY --from=builder /app/dist /usr/share/nginx/html
 COPY nginx.conf /etc/nginx/nginx.conf
+
+# Create empty api-proxy conf (overwritten at startup for WAF/private deployments)
+RUN mkdir -p /etc/nginx/conf.d && touch /etc/nginx/conf.d/api-proxy.conf
+
 COPY startup.sh /docker-entrypoint.d/startup.sh
 RUN chmod +x /docker-entrypoint.d/startup.sh
 RUN sed -i 's/\r$//' /docker-entrypoint.d/startup.sh

--- a/chat-app/frontend/nginx.conf
+++ b/chat-app/frontend/nginx.conf
@@ -12,6 +12,9 @@ http {
         root /usr/share/nginx/html;
         index index.html;
 
+        # Include API proxy config (generated at startup for WAF/private networking deployments)
+        include /etc/nginx/conf.d/api-proxy.conf;
+
         # Handle React Router
         location / {
             try_files $uri $uri/ /index.html;

--- a/chat-app/frontend/startup.sh
+++ b/chat-app/frontend/startup.sh
@@ -31,14 +31,16 @@ fi
 # When BACKEND_API_URL is set the backend API is private and this frontend's
 # nginx proxies /api/ requests to it over the VNet.
 if [ -n "${BACKEND_API_URL}" ]; then
-  BACKEND_HOST=$(echo "${BACKEND_API_URL}" | sed 's|https://||; s|http://||; s|/.*||')
+  # Strip any trailing slash so proxy_pass + the /api/ location prefix don't produce a malformed path.
+  BACKEND_API_URL="${BACKEND_API_URL%/}"
+  BACKEND_HOST=$(printf '%s' "${BACKEND_API_URL}" | sed 's|https\?://||; s|/.*||')
   cat > /etc/nginx/conf.d/api-proxy.conf << PROXYEOF
 # Reverse proxy for backend API - WAF private networking deployment
 location /api/ {
     resolver 168.63.129.16 valid=30s;
     set \$backend "${BACKEND_API_URL}";
     proxy_pass \$backend;
-    proxy_set_header Host ${BACKEND_HOST};
+    proxy_set_header Host "${BACKEND_HOST}";
     proxy_set_header X-Real-IP \$remote_addr;
     proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto \$scheme;

--- a/chat-app/frontend/startup.sh
+++ b/chat-app/frontend/startup.sh
@@ -1,19 +1,61 @@
 #!/bin/sh
 
-if [ -z "$VITE_API_BASE_URL" ]; then
-  host="${WEBSITE_HOSTNAME:-}"
-  case "$host" in
-    app-chat-*.*)
-      suf="${host#app-chat-}"
-      VITE_API_BASE_URL="https://api-chat-${suf}"
-      ;;
-  esac
-fi
+# WAF/private networking deployment: BACKEND_API_URL is set when the backend API
+# is private. The SPA then calls its own origin (nginx reverse-proxies /api/ to
+# the private backend over the VNet).
+if [ -n "${BACKEND_API_URL}" ]; then
+cat > /usr/share/nginx/html/runtime-config.js << 'RUNTIMEEOF'
+window.__RUNTIME_CONFIG__ = {
+  VITE_API_BASE_URL: window.location.origin
+};
+RUNTIMEEOF
+else
+  if [ -z "$VITE_API_BASE_URL" ]; then
+    host="${WEBSITE_HOSTNAME:-}"
+    case "$host" in
+      app-chat-*.*)
+        suf="${host#app-chat-}"
+        VITE_API_BASE_URL="https://api-chat-${suf}"
+        ;;
+    esac
+  fi
 
 cat > /usr/share/nginx/html/runtime-config.js << EOF
 window.__RUNTIME_CONFIG__ = {
   VITE_API_BASE_URL: '${VITE_API_BASE_URL}'
 };
 EOF
+fi
 
-nginx -g "daemon off;"
+# Generate the API reverse proxy config for WAF/private networking deployments.
+# When BACKEND_API_URL is set the backend API is private and this frontend's
+# nginx proxies /api/ requests to it over the VNet.
+if [ -n "${BACKEND_API_URL}" ]; then
+  BACKEND_HOST=$(echo "${BACKEND_API_URL}" | sed 's|https://||; s|http://||; s|/.*||')
+  cat > /etc/nginx/conf.d/api-proxy.conf << PROXYEOF
+# Reverse proxy for backend API - WAF private networking deployment
+location /api/ {
+    resolver 168.63.129.16 valid=30s;
+    set \$backend "${BACKEND_API_URL}";
+    proxy_pass \$backend;
+    proxy_set_header Host ${BACKEND_HOST};
+    proxy_set_header X-Real-IP \$remote_addr;
+    proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto \$scheme;
+    proxy_ssl_server_name on;
+    proxy_read_timeout 300s;
+    proxy_connect_timeout 60s;
+    proxy_buffering off;
+
+    # WebSocket support (needed for /api/voice/ws/... connections)
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade \$http_upgrade;
+    proxy_set_header Connection "upgrade";
+}
+PROXYEOF
+else
+  # Empty file for non-WAF deployments (ensures the nginx include does not error)
+  > /etc/nginx/conf.d/api-proxy.conf
+fi
+
+exec nginx -g "daemon off;"

--- a/infra/avm/main.bicep
+++ b/infra/avm/main.bicep
@@ -836,26 +836,26 @@ module chat_backend_app './modules/compute/app-service.bicep' = {
     enableTelemetry: enableTelemetry
     diagnosticSettings: monitoringDiagnosticSettings
     applicationInsightResourceId: enableMonitoring ? app_insights!.outputs.resourceId : ''
-    publicNetworkAccess: 'Enabled' // enablePrivateNetworking ? 'Disabled' : 'Enabled'
+    publicNetworkAccess: enablePrivateNetworking ? 'Disabled' : 'Enabled'
     virtualNetworkSubnetId: enablePrivateNetworking ? virtualNetwork!.outputs.webserverfarmSubnetResourceId : ''
     vnetRouteAllEnabled: enablePrivateNetworking
     imagePullTraffic: enablePrivateNetworking
     acrUseManagedIdentityCreds: true
-    // privateEndpoints: enablePrivateNetworking
-    //   ? [
-    //       {
-    //         name: 'pep-chat-api-${solutionSuffix}'
-    //         customNetworkInterfaceName: 'nic-chat-api-${solutionSuffix}'
-    //         privateDnsZoneGroup: {
-    //           privateDnsZoneGroupConfigs: [
-    //             { privateDnsZoneResourceId: privateDnsZoneDeployments[dnsZoneIndex.webApp]!.outputs.resourceId }
-    //           ]
-    //         }
-    //         service: 'sites'
-    //         subnetResourceId: virtualNetwork!.outputs.backendSubnetResourceId
-    //       }
-    //     ]
-    //   : []
+    privateEndpoints: enablePrivateNetworking
+      ? [
+          {
+            name: 'pep-chat-api-${solutionSuffix}'
+            customNetworkInterfaceName: 'nic-chat-api-${solutionSuffix}'
+            privateDnsZoneGroup: {
+              privateDnsZoneGroupConfigs: [
+                { privateDnsZoneResourceId: privateDnsZoneDeployments[dnsZoneIndex.webApp]!.outputs.resourceId }
+              ]
+            }
+            service: 'sites'
+            subnetResourceId: virtualNetwork!.outputs.backendSubnetResourceId
+          }
+        ]
+      : []
     appSettings: {
       AZURE_OPENAI_DEPLOYMENT_MODEL: gptModelName
       AZURE_OPENAI_ENDPOINT: aiFoundryEndpoint
@@ -931,8 +931,8 @@ module chat_frontend_app './modules/compute/app-service.bicep' = {
     imagePullTraffic: enablePrivateNetworking
     appSettings: {
       NODE_ENV: 'production'
-      VITE_API_BASE_URL: chat_backend_app.outputs.appUrl // enablePrivateNetworking ? '' : chat_backend_app.outputs.appUrl
-      // BACKEND_API_URL: enablePrivateNetworking ? chat_backend_app.outputs.appUrl : ''
+      VITE_API_BASE_URL: enablePrivateNetworking ? '' : chat_backend_app.outputs.appUrl
+      BACKEND_API_URL: enablePrivateNetworking ? chat_backend_app.outputs.appUrl : ''
       DEPLOYMENT_SCENARIO: deploymentScenario
       VITE_SCENARIO: deploymentScenario
       CHAT_WELCOME_TITLE: chatWelcomeTitle
@@ -958,26 +958,26 @@ module scenario_backend_app './modules/compute/app-service.bicep' = {
     enableTelemetry: enableTelemetry
     diagnosticSettings: monitoringDiagnosticSettings
     applicationInsightResourceId: enableMonitoring ? app_insights!.outputs.resourceId : ''
-    publicNetworkAccess: 'Enabled' //enablePrivateNetworking ? 'Disabled' : 'Enabled'
+    publicNetworkAccess: enablePrivateNetworking ? 'Disabled' : 'Enabled'
     virtualNetworkSubnetId: enablePrivateNetworking ? virtualNetwork!.outputs.webserverfarmSubnetResourceId : ''
     vnetRouteAllEnabled: enablePrivateNetworking
     imagePullTraffic: enablePrivateNetworking
     acrUseManagedIdentityCreds: true
-    // privateEndpoints: enablePrivateNetworking
-    //   ? [
-    //       {
-    //         name: 'pep-scenario-api-${solutionSuffix}'
-    //         customNetworkInterfaceName: 'nic-scenario-api-${solutionSuffix}'
-    //         privateDnsZoneGroup: {
-    //           privateDnsZoneGroupConfigs: [
-    //             { privateDnsZoneResourceId: privateDnsZoneDeployments[dnsZoneIndex.webApp]!.outputs.resourceId }
-    //           ]
-    //         }
-    //         service: 'sites'
-    //         subnetResourceId: virtualNetwork!.outputs.backendSubnetResourceId
-    //       }
-    //     ]
-    //   : []
+    privateEndpoints: enablePrivateNetworking
+      ? [
+          {
+            name: 'pep-scenario-api-${solutionSuffix}'
+            customNetworkInterfaceName: 'nic-scenario-api-${solutionSuffix}'
+            privateDnsZoneGroup: {
+              privateDnsZoneGroupConfigs: [
+                { privateDnsZoneResourceId: privateDnsZoneDeployments[dnsZoneIndex.webApp]!.outputs.resourceId }
+              ]
+            }
+            service: 'sites'
+            subnetResourceId: virtualNetwork!.outputs.backendSubnetResourceId
+          }
+        ]
+      : []
     appSettings: {
       AZURE_OPENAI_DEPLOYMENT_MODEL: gptModelName
       AZURE_OPENAI_ENDPOINT: aiFoundryEndpoint
@@ -1049,9 +1049,9 @@ module scenario_frontend_app './modules/compute/app-service.bicep' = {
     acrUseManagedIdentityCreds: true
     appSettings: {
       NODE_ENV: 'production'
-      VITE_API_BASE_URL: scenario_backend_app.outputs.appUrl // enablePrivateNetworking ? '' : scenario_backend_app.outputs.appUrl
-      VITE_CHAT_API_BASE_URL: chat_backend_app.outputs.appUrl
-      // BACKEND_API_URL: enablePrivateNetworking ? scenario_backend_app.outputs.appUrl : ''
+      VITE_API_BASE_URL: enablePrivateNetworking ? '' : scenario_backend_app.outputs.appUrl
+      BACKEND_API_URL: enablePrivateNetworking ? scenario_backend_app.outputs.appUrl : ''
+      VITE_CHAT_API_BASE_URL: enablePrivateNetworking ? 'https://${chatWebAppName}.azurewebsites.net' : chat_backend_app.outputs.appUrl
       DEPLOYMENT_SCENARIO: deploymentScenario
       VITE_SCENARIO: deploymentScenario
       VITE_HOST_APP_TITLE: hostAppTitle

--- a/infra/avm/main.json
+++ b/infra/avm/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.46.1.21595",
-      "templateHash": "15729196358454583172"
+      "version": "0.44.1.10279",
+      "templateHash": "6878936743691508459"
     }
   },
   "parameters": {
@@ -383,7 +383,7 @@
     "policiesSearchIndex": "[if(equals(parameters('deploymentScenario'), 'healthcare'), 'care_policies_index', if(equals(parameters('deploymentScenario'), 'banking'), 'banking_policies_index', 'policies_index'))]",
     "catalogToolName": "[if(equals(parameters('deploymentScenario'), 'healthcare'), 'services_agent', if(equals(parameters('deploymentScenario'), 'banking'), 'accounts_agent', 'product_agent'))]",
     "policyToolName": "[if(equals(parameters('deploymentScenario'), 'healthcare'), 'care_policy_agent', if(equals(parameters('deploymentScenario'), 'banking'), 'banking_policy_agent', 'policy_agent'))]",
-    "reactAppLayoutConfig": "{\n  \"appConfig\": {\n      \"CHAT_CHATHISTORY\": {\n        \"CHAT\": 70,\n        \"CHATHISTORY\": 30\n      }\n    }\n  }\n}"
+    "reactAppLayoutConfig": "{\r\n  \"appConfig\": {\r\n      \"CHAT_CHATHISTORY\": {\r\n        \"CHAT\": 70,\r\n        \"CHATHISTORY\": 30\r\n      }\r\n    }\r\n  }\r\n}"
   },
   "resources": {
     "resourceGroupTags": {
@@ -445,8 +445,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.46.1.21595",
-              "templateHash": "5005969515455354504"
+              "version": "0.44.1.10279",
+              "templateHash": "3232047823815133881"
             }
           },
           "parameters": {
@@ -3747,8 +3747,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.46.1.21595",
-              "templateHash": "1077806126224374403"
+              "version": "0.44.1.10279",
+              "templateHash": "5783288507350094145"
             }
           },
           "parameters": {
@@ -4674,8 +4674,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.46.1.21595",
-              "templateHash": "14375623146044395014"
+              "version": "0.44.1.10279",
+              "templateHash": "17026638034178729316"
             }
           },
           "definitions": {
@@ -7540,8 +7540,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.46.1.21595",
-              "templateHash": "4613446280405157854"
+              "version": "0.44.1.10279",
+              "templateHash": "13928883839220797481"
             }
           },
           "parameters": {
@@ -9444,8 +9444,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.46.1.21595",
-              "templateHash": "8420279536133240728"
+              "version": "0.44.1.10279",
+              "templateHash": "1680554660663753024"
             }
           },
           "parameters": {
@@ -9984,8 +9984,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.46.1.21595",
-              "templateHash": "14701803776432038764"
+              "version": "0.44.1.10279",
+              "templateHash": "10734514187033998183"
             }
           },
           "parameters": {
@@ -11453,8 +11453,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.46.1.21595",
-              "templateHash": "13006336383696924611"
+              "version": "0.44.1.10279",
+              "templateHash": "14627790702698637496"
             }
           },
           "parameters": {
@@ -11962,8 +11962,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.46.1.21595",
-              "templateHash": "17976113817590025731"
+              "version": "0.44.1.10279",
+              "templateHash": "11639188571768358148"
             }
           },
           "parameters": {
@@ -21318,8 +21318,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.46.1.21595",
-              "templateHash": "11076758087490966511"
+              "version": "0.44.1.10279",
+              "templateHash": "8816372137748980601"
             }
           },
           "parameters": {
@@ -24826,8 +24826,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.46.1.21595",
-              "templateHash": "45267059275214483"
+              "version": "0.44.1.10279",
+              "templateHash": "15866619731095149829"
             }
           },
           "parameters": {
@@ -27626,8 +27626,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.46.1.21595",
-              "templateHash": "14933983914799613850"
+              "version": "0.44.1.10279",
+              "templateHash": "943732916029725835"
             }
           },
           "parameters": {
@@ -28343,8 +28343,8 @@
       "dependsOn": [
         "ai_foundry_project",
         "[format('privateDnsZoneDeployments[{0}]', variables('dnsZoneIndex').aiServices)]",
-        "[format('privateDnsZoneDeployments[{0}]', variables('dnsZoneIndex').cognitiveServices)]",
         "[format('privateDnsZoneDeployments[{0}]', variables('dnsZoneIndex').openAI)]",
+        "[format('privateDnsZoneDeployments[{0}]', variables('dnsZoneIndex').cognitiveServices)]",
         "virtualNetwork"
       ]
     },
@@ -28374,8 +28374,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.46.1.21595",
-              "templateHash": "14734711829211982487"
+              "version": "0.44.1.10279",
+              "templateHash": "5479596076171286810"
             }
           },
           "parameters": {
@@ -28512,8 +28512,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.46.1.21595",
-              "templateHash": "5315493943580072668"
+              "version": "0.44.1.10279",
+              "templateHash": "10180502016624897684"
             }
           },
           "parameters": {
@@ -28680,8 +28680,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.46.1.21595",
-              "templateHash": "16968649656855146631"
+              "version": "0.44.1.10279",
+              "templateHash": "371928985555429960"
             }
           },
           "definitions": {
@@ -31369,8 +31369,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.46.1.21595",
-              "templateHash": "716687752517927296"
+              "version": "0.44.1.10279",
+              "templateHash": "6391723411041592681"
             }
           },
           "parameters": {
@@ -31564,8 +31564,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.46.1.21595",
-              "templateHash": "17841877567317429172"
+              "version": "0.44.1.10279",
+              "templateHash": "709954433606367454"
             }
           },
           "definitions": {
@@ -38115,8 +38115,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.46.1.21595",
-              "templateHash": "1341821364014447993"
+              "version": "0.44.1.10279",
+              "templateHash": "13851921925562787404"
             }
           },
           "definitions": {
@@ -42565,8 +42565,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.46.1.21595",
-              "templateHash": "15442179113759093660"
+              "version": "0.44.1.10279",
+              "templateHash": "1571277744110287631"
             }
           },
           "parameters": {
@@ -43466,9 +43466,7 @@
           },
           "diagnosticSettings": "[if(parameters('enableMonitoring'), createObject('value', createArray(createObject('workspaceResourceId', if(parameters('enableMonitoring'), if(variables('useExistingLogAnalytics'), extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', split(parameters('existingLogAnalyticsWorkspaceId'), '/')[2], split(parameters('existingLogAnalyticsWorkspaceId'), '/')[4]), 'Microsoft.OperationalInsights/workspaces', split(parameters('existingLogAnalyticsWorkspaceId'), '/')[8]), reference('log_analytics').outputs.resourceId.value), '')))), createObject('value', createArray()))]",
           "applicationInsightResourceId": "[if(parameters('enableMonitoring'), createObject('value', reference('app_insights').outputs.resourceId.value), createObject('value', ''))]",
-          "publicNetworkAccess": {
-            "value": "Enabled"
-          },
+          "publicNetworkAccess": "[if(parameters('enablePrivateNetworking'), createObject('value', 'Disabled'), createObject('value', 'Enabled'))]",
           "virtualNetworkSubnetId": "[if(parameters('enablePrivateNetworking'), createObject('value', reference('virtualNetwork').outputs.webserverfarmSubnetResourceId.value), createObject('value', ''))]",
           "vnetRouteAllEnabled": {
             "value": "[parameters('enablePrivateNetworking')]"
@@ -43479,6 +43477,7 @@
           "acrUseManagedIdentityCreds": {
             "value": true
           },
+          "privateEndpoints": "[if(parameters('enablePrivateNetworking'), createObject('value', createArray(createObject('name', format('pep-chat-api-{0}', variables('solutionSuffix')), 'customNetworkInterfaceName', format('nic-chat-api-{0}', variables('solutionSuffix')), 'privateDnsZoneGroup', createObject('privateDnsZoneGroupConfigs', createArray(createObject('privateDnsZoneResourceId', reference(format('privateDnsZoneDeployments[{0}]', variables('dnsZoneIndex').webApp)).outputs.resourceId.value))), 'service', 'sites', 'subnetResourceId', reference('virtualNetwork').outputs.backendSubnetResourceId.value))), createObject('value', createArray()))]",
           "appSettings": {
             "value": {
               "AZURE_OPENAI_DEPLOYMENT_MODEL": "[parameters('gptModelName')]",
@@ -43542,8 +43541,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.46.1.21595",
-              "templateHash": "11236004869715473159"
+              "version": "0.44.1.10279",
+              "templateHash": "2971165412380728978"
             }
           },
           "definitions": {
@@ -59039,6 +59038,7 @@
         "foundry_search_connection",
         "hostingplan",
         "log_analytics",
+        "[format('privateDnsZoneDeployments[{0}]', variables('dnsZoneIndex').webApp)]",
         "virtualNetwork"
       ]
     },
@@ -59092,7 +59092,8 @@
           "appSettings": {
             "value": {
               "NODE_ENV": "production",
-              "VITE_API_BASE_URL": "[reference('chat_backend_app').outputs.appUrl.value]",
+              "VITE_API_BASE_URL": "[if(parameters('enablePrivateNetworking'), '', reference('chat_backend_app').outputs.appUrl.value)]",
+              "BACKEND_API_URL": "[if(parameters('enablePrivateNetworking'), reference('chat_backend_app').outputs.appUrl.value, '')]",
               "DEPLOYMENT_SCENARIO": "[parameters('deploymentScenario')]",
               "VITE_SCENARIO": "[parameters('deploymentScenario')]",
               "CHAT_WELCOME_TITLE": "[variables('chatWelcomeTitle')]",
@@ -59108,8 +59109,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.46.1.21595",
-              "templateHash": "11236004869715473159"
+              "version": "0.44.1.10279",
+              "templateHash": "2971165412380728978"
             }
           },
           "definitions": {
@@ -74646,9 +74647,7 @@
           },
           "diagnosticSettings": "[if(parameters('enableMonitoring'), createObject('value', createArray(createObject('workspaceResourceId', if(parameters('enableMonitoring'), if(variables('useExistingLogAnalytics'), extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', split(parameters('existingLogAnalyticsWorkspaceId'), '/')[2], split(parameters('existingLogAnalyticsWorkspaceId'), '/')[4]), 'Microsoft.OperationalInsights/workspaces', split(parameters('existingLogAnalyticsWorkspaceId'), '/')[8]), reference('log_analytics').outputs.resourceId.value), '')))), createObject('value', createArray()))]",
           "applicationInsightResourceId": "[if(parameters('enableMonitoring'), createObject('value', reference('app_insights').outputs.resourceId.value), createObject('value', ''))]",
-          "publicNetworkAccess": {
-            "value": "Enabled"
-          },
+          "publicNetworkAccess": "[if(parameters('enablePrivateNetworking'), createObject('value', 'Disabled'), createObject('value', 'Enabled'))]",
           "virtualNetworkSubnetId": "[if(parameters('enablePrivateNetworking'), createObject('value', reference('virtualNetwork').outputs.webserverfarmSubnetResourceId.value), createObject('value', ''))]",
           "vnetRouteAllEnabled": {
             "value": "[parameters('enablePrivateNetworking')]"
@@ -74659,6 +74658,7 @@
           "acrUseManagedIdentityCreds": {
             "value": true
           },
+          "privateEndpoints": "[if(parameters('enablePrivateNetworking'), createObject('value', createArray(createObject('name', format('pep-scenario-api-{0}', variables('solutionSuffix')), 'customNetworkInterfaceName', format('nic-scenario-api-{0}', variables('solutionSuffix')), 'privateDnsZoneGroup', createObject('privateDnsZoneGroupConfigs', createArray(createObject('privateDnsZoneResourceId', reference(format('privateDnsZoneDeployments[{0}]', variables('dnsZoneIndex').webApp)).outputs.resourceId.value))), 'service', 'sites', 'subnetResourceId', reference('virtualNetwork').outputs.backendSubnetResourceId.value))), createObject('value', createArray()))]",
           "appSettings": {
             "value": {
               "AZURE_OPENAI_DEPLOYMENT_MODEL": "[parameters('gptModelName')]",
@@ -74716,8 +74716,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.46.1.21595",
-              "templateHash": "11236004869715473159"
+              "version": "0.44.1.10279",
+              "templateHash": "2971165412380728978"
             }
           },
           "definitions": {
@@ -90213,6 +90213,7 @@
         "foundry_search_connection",
         "hostingplan",
         "log_analytics",
+        "[format('privateDnsZoneDeployments[{0}]', variables('dnsZoneIndex').webApp)]",
         "virtualNetwork"
       ]
     },
@@ -90268,8 +90269,9 @@
           "appSettings": {
             "value": {
               "NODE_ENV": "production",
-              "VITE_API_BASE_URL": "[reference('scenario_backend_app').outputs.appUrl.value]",
-              "VITE_CHAT_API_BASE_URL": "[reference('chat_backend_app').outputs.appUrl.value]",
+              "VITE_API_BASE_URL": "[if(parameters('enablePrivateNetworking'), '', reference('scenario_backend_app').outputs.appUrl.value)]",
+              "BACKEND_API_URL": "[if(parameters('enablePrivateNetworking'), reference('scenario_backend_app').outputs.appUrl.value, '')]",
+              "VITE_CHAT_API_BASE_URL": "[if(parameters('enablePrivateNetworking'), format('https://{0}.azurewebsites.net', variables('chatWebAppName')), reference('chat_backend_app').outputs.appUrl.value)]",
               "DEPLOYMENT_SCENARIO": "[parameters('deploymentScenario')]",
               "VITE_SCENARIO": "[parameters('deploymentScenario')]",
               "VITE_HOST_APP_TITLE": "[variables('hostAppTitle')]",
@@ -90285,8 +90287,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.46.1.21595",
-              "templateHash": "11236004869715473159"
+              "version": "0.44.1.10279",
+              "templateHash": "2971165412380728978"
             }
           },
           "definitions": {
@@ -105828,8 +105830,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.46.1.21595",
-              "templateHash": "14428393433289701976"
+              "version": "0.44.1.10279",
+              "templateHash": "6923046573019210252"
             }
           },
           "parameters": {
@@ -106044,8 +106046,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.46.1.21595",
-                      "templateHash": "14185496479700676156"
+                      "version": "0.44.1.10279",
+                      "templateHash": "7322574716979180114"
                     }
                   },
                   "parameters": {
@@ -106166,8 +106168,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.46.1.21595",
-                      "templateHash": "14185496479700676156"
+                      "version": "0.44.1.10279",
+                      "templateHash": "7322574716979180114"
                     }
                   },
                   "parameters": {

--- a/infra/avm/main.json
+++ b/infra/avm/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.44.1.10279",
-      "templateHash": "6878936743691508459"
+      "version": "0.46.1.21595",
+      "templateHash": "5166718318626472799"
     }
   },
   "parameters": {
@@ -383,7 +383,7 @@
     "policiesSearchIndex": "[if(equals(parameters('deploymentScenario'), 'healthcare'), 'care_policies_index', if(equals(parameters('deploymentScenario'), 'banking'), 'banking_policies_index', 'policies_index'))]",
     "catalogToolName": "[if(equals(parameters('deploymentScenario'), 'healthcare'), 'services_agent', if(equals(parameters('deploymentScenario'), 'banking'), 'accounts_agent', 'product_agent'))]",
     "policyToolName": "[if(equals(parameters('deploymentScenario'), 'healthcare'), 'care_policy_agent', if(equals(parameters('deploymentScenario'), 'banking'), 'banking_policy_agent', 'policy_agent'))]",
-    "reactAppLayoutConfig": "{\r\n  \"appConfig\": {\r\n      \"CHAT_CHATHISTORY\": {\r\n        \"CHAT\": 70,\r\n        \"CHATHISTORY\": 30\r\n      }\r\n    }\r\n  }\r\n}"
+    "reactAppLayoutConfig": "{\n  \"appConfig\": {\n      \"CHAT_CHATHISTORY\": {\n        \"CHAT\": 70,\n        \"CHATHISTORY\": 30\n      }\n    }\n  }\n}"
   },
   "resources": {
     "resourceGroupTags": {
@@ -445,8 +445,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.44.1.10279",
-              "templateHash": "3232047823815133881"
+              "version": "0.46.1.21595",
+              "templateHash": "5005969515455354504"
             }
           },
           "parameters": {
@@ -3747,8 +3747,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.44.1.10279",
-              "templateHash": "5783288507350094145"
+              "version": "0.46.1.21595",
+              "templateHash": "1077806126224374403"
             }
           },
           "parameters": {
@@ -4674,8 +4674,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.44.1.10279",
-              "templateHash": "17026638034178729316"
+              "version": "0.46.1.21595",
+              "templateHash": "14375623146044395014"
             }
           },
           "definitions": {
@@ -7540,8 +7540,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.44.1.10279",
-              "templateHash": "13928883839220797481"
+              "version": "0.46.1.21595",
+              "templateHash": "4613446280405157854"
             }
           },
           "parameters": {
@@ -9444,8 +9444,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.44.1.10279",
-              "templateHash": "1680554660663753024"
+              "version": "0.46.1.21595",
+              "templateHash": "8420279536133240728"
             }
           },
           "parameters": {
@@ -9984,8 +9984,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.44.1.10279",
-              "templateHash": "10734514187033998183"
+              "version": "0.46.1.21595",
+              "templateHash": "14701803776432038764"
             }
           },
           "parameters": {
@@ -11453,8 +11453,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.44.1.10279",
-              "templateHash": "14627790702698637496"
+              "version": "0.46.1.21595",
+              "templateHash": "13006336383696924611"
             }
           },
           "parameters": {
@@ -11962,8 +11962,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.44.1.10279",
-              "templateHash": "11639188571768358148"
+              "version": "0.46.1.21595",
+              "templateHash": "17976113817590025731"
             }
           },
           "parameters": {
@@ -21318,8 +21318,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.44.1.10279",
-              "templateHash": "8816372137748980601"
+              "version": "0.46.1.21595",
+              "templateHash": "11076758087490966511"
             }
           },
           "parameters": {
@@ -24826,8 +24826,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.44.1.10279",
-              "templateHash": "15866619731095149829"
+              "version": "0.46.1.21595",
+              "templateHash": "45267059275214483"
             }
           },
           "parameters": {
@@ -27626,8 +27626,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.44.1.10279",
-              "templateHash": "943732916029725835"
+              "version": "0.46.1.21595",
+              "templateHash": "14933983914799613850"
             }
           },
           "parameters": {
@@ -28342,9 +28342,9 @@
       },
       "dependsOn": [
         "ai_foundry_project",
+        "[format('privateDnsZoneDeployments[{0}]', variables('dnsZoneIndex').cognitiveServices)]",
         "[format('privateDnsZoneDeployments[{0}]', variables('dnsZoneIndex').aiServices)]",
         "[format('privateDnsZoneDeployments[{0}]', variables('dnsZoneIndex').openAI)]",
-        "[format('privateDnsZoneDeployments[{0}]', variables('dnsZoneIndex').cognitiveServices)]",
         "virtualNetwork"
       ]
     },
@@ -28374,8 +28374,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.44.1.10279",
-              "templateHash": "5479596076171286810"
+              "version": "0.46.1.21595",
+              "templateHash": "14734711829211982487"
             }
           },
           "parameters": {
@@ -28512,8 +28512,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.44.1.10279",
-              "templateHash": "10180502016624897684"
+              "version": "0.46.1.21595",
+              "templateHash": "5315493943580072668"
             }
           },
           "parameters": {
@@ -28680,8 +28680,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.44.1.10279",
-              "templateHash": "371928985555429960"
+              "version": "0.46.1.21595",
+              "templateHash": "16968649656855146631"
             }
           },
           "definitions": {
@@ -31369,8 +31369,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.44.1.10279",
-              "templateHash": "6391723411041592681"
+              "version": "0.46.1.21595",
+              "templateHash": "716687752517927296"
             }
           },
           "parameters": {
@@ -31564,8 +31564,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.44.1.10279",
-              "templateHash": "709954433606367454"
+              "version": "0.46.1.21595",
+              "templateHash": "17841877567317429172"
             }
           },
           "definitions": {
@@ -38115,8 +38115,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.44.1.10279",
-              "templateHash": "13851921925562787404"
+              "version": "0.46.1.21595",
+              "templateHash": "1341821364014447993"
             }
           },
           "definitions": {
@@ -42565,8 +42565,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.44.1.10279",
-              "templateHash": "1571277744110287631"
+              "version": "0.46.1.21595",
+              "templateHash": "15442179113759093660"
             }
           },
           "parameters": {
@@ -43541,8 +43541,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.44.1.10279",
-              "templateHash": "2971165412380728978"
+              "version": "0.46.1.21595",
+              "templateHash": "11236004869715473159"
             }
           },
           "definitions": {
@@ -59109,8 +59109,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.44.1.10279",
-              "templateHash": "2971165412380728978"
+              "version": "0.46.1.21595",
+              "templateHash": "11236004869715473159"
             }
           },
           "definitions": {
@@ -74716,8 +74716,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.44.1.10279",
-              "templateHash": "2971165412380728978"
+              "version": "0.46.1.21595",
+              "templateHash": "11236004869715473159"
             }
           },
           "definitions": {
@@ -90287,8 +90287,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.44.1.10279",
-              "templateHash": "2971165412380728978"
+              "version": "0.46.1.21595",
+              "templateHash": "11236004869715473159"
             }
           },
           "definitions": {
@@ -105830,8 +105830,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.44.1.10279",
-              "templateHash": "6923046573019210252"
+              "version": "0.46.1.21595",
+              "templateHash": "14428393433289701976"
             }
           },
           "parameters": {
@@ -106046,8 +106046,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.44.1.10279",
-                      "templateHash": "7322574716979180114"
+                      "version": "0.46.1.21595",
+                      "templateHash": "14185496479700676156"
                     }
                   },
                   "parameters": {
@@ -106168,8 +106168,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.44.1.10279",
-                      "templateHash": "7322574716979180114"
+                      "version": "0.46.1.21595",
+                      "templateHash": "14185496479700676156"
                     }
                   },
                   "parameters": {

--- a/infra/main.json
+++ b/infra/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.46.1.21595",
-      "templateHash": "15335554942073237241"
+      "version": "0.44.1.10279",
+      "templateHash": "6515409251207683035"
     }
   },
   "parameters": {
@@ -387,8 +387,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.46.1.21595",
-              "templateHash": "9629672312866105058"
+              "version": "0.44.1.10279",
+              "templateHash": "9212219831260544815"
             }
           },
           "parameters": {
@@ -671,7 +671,7 @@
             "policiesSearchIndex": "[if(equals(parameters('deploymentScenario'), 'healthcare'), 'care_policies_index', if(equals(parameters('deploymentScenario'), 'banking'), 'banking_policies_index', 'policies_index'))]",
             "catalogToolName": "[if(equals(parameters('deploymentScenario'), 'healthcare'), 'services_agent', if(equals(parameters('deploymentScenario'), 'banking'), 'accounts_agent', 'product_agent'))]",
             "policyToolName": "[if(equals(parameters('deploymentScenario'), 'healthcare'), 'care_policy_agent', if(equals(parameters('deploymentScenario'), 'banking'), 'banking_policy_agent', 'policy_agent'))]",
-            "reactAppLayoutConfig": "{\n  \"appConfig\": {\n      \"CHAT_CHATHISTORY\": {\n        \"CHAT\": 70,\n        \"CHATHISTORY\": 30\n      }\n    }\n  }\n}"
+            "reactAppLayoutConfig": "{\r\n  \"appConfig\": {\r\n      \"CHAT_CHATHISTORY\": {\r\n        \"CHAT\": 70,\r\n        \"CHATHISTORY\": 30\r\n      }\r\n    }\r\n  }\r\n}"
           },
           "resources": [
             {
@@ -707,8 +707,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.46.1.21595",
-                      "templateHash": "3561501102733674034"
+                      "version": "0.44.1.10279",
+                      "templateHash": "18362209914173142473"
                     }
                   },
                   "parameters": {
@@ -837,8 +837,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.46.1.21595",
-                      "templateHash": "2461614014827306322"
+                      "version": "0.44.1.10279",
+                      "templateHash": "3199910078817503702"
                     }
                   },
                   "parameters": {
@@ -997,8 +997,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.46.1.21595",
-                      "templateHash": "10528706051101679884"
+                      "version": "0.44.1.10279",
+                      "templateHash": "9172330732311277268"
                     }
                   },
                   "parameters": {
@@ -1222,8 +1222,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.46.1.21595",
-                      "templateHash": "10331016231175084282"
+                      "version": "0.44.1.10279",
+                      "templateHash": "4978423908175488703"
                     }
                   },
                   "parameters": {
@@ -1360,8 +1360,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.46.1.21595",
-                      "templateHash": "5315493943580072668"
+                      "version": "0.44.1.10279",
+                      "templateHash": "10180502016624897684"
                     }
                   },
                   "parameters": {
@@ -1498,8 +1498,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.46.1.21595",
-                      "templateHash": "5701731356162862350"
+                      "version": "0.44.1.10279",
+                      "templateHash": "13476994621581605010"
                     }
                   },
                   "parameters": {
@@ -1687,8 +1687,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.46.1.21595",
-                              "templateHash": "11160875200628826596"
+                              "version": "0.44.1.10279",
+                              "templateHash": "2357632753579583529"
                             }
                           },
                           "parameters": {
@@ -1902,8 +1902,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.46.1.21595",
-                      "templateHash": "716687752517927296"
+                      "version": "0.44.1.10279",
+                      "templateHash": "6391723411041592681"
                     }
                   },
                   "parameters": {
@@ -2085,8 +2085,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.46.1.21595",
-                      "templateHash": "16930840148567813821"
+                      "version": "0.44.1.10279",
+                      "templateHash": "17334509417641963470"
                     }
                   },
                   "parameters": {
@@ -2299,8 +2299,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.46.1.21595",
-                      "templateHash": "14293411736980892825"
+                      "version": "0.44.1.10279",
+                      "templateHash": "6730962297935458636"
                     }
                   },
                   "parameters": {
@@ -2469,8 +2469,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.46.1.21595",
-                      "templateHash": "17503458259299065073"
+                      "version": "0.44.1.10279",
+                      "templateHash": "8496143357348681814"
                     }
                   },
                   "parameters": {
@@ -2703,8 +2703,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.46.1.21595",
-                      "templateHash": "15416323965013625336"
+                      "version": "0.44.1.10279",
+                      "templateHash": "15104078240780944367"
                     }
                   },
                   "parameters": {
@@ -3011,8 +3011,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.46.1.21595",
-                      "templateHash": "15416323965013625336"
+                      "version": "0.44.1.10279",
+                      "templateHash": "15104078240780944367"
                     }
                   },
                   "parameters": {
@@ -3359,8 +3359,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.46.1.21595",
-                      "templateHash": "15416323965013625336"
+                      "version": "0.44.1.10279",
+                      "templateHash": "15104078240780944367"
                     }
                   },
                   "parameters": {
@@ -3668,8 +3668,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.46.1.21595",
-                      "templateHash": "15416323965013625336"
+                      "version": "0.44.1.10279",
+                      "templateHash": "15104078240780944367"
                     }
                   },
                   "parameters": {
@@ -3978,8 +3978,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.46.1.21595",
-                      "templateHash": "15322885636837012121"
+                      "version": "0.44.1.10279",
+                      "templateHash": "9397001796125384955"
                     }
                   },
                   "parameters": {
@@ -4321,8 +4321,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.46.1.21595",
-                              "templateHash": "1001648557732946394"
+                              "version": "0.44.1.10279",
+                              "templateHash": "15240584362831878613"
                             }
                           },
                           "parameters": {
@@ -4443,8 +4443,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.46.1.21595",
-                              "templateHash": "1001648557732946394"
+                              "version": "0.44.1.10279",
+                              "templateHash": "15240584362831878613"
                             }
                           },
                           "parameters": {
@@ -5007,8 +5007,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.46.1.21595",
-              "templateHash": "18240649482965484110"
+              "version": "0.44.1.10279",
+              "templateHash": "7642203634815326815"
             }
           },
           "parameters": {
@@ -5385,7 +5385,7 @@
             "policiesSearchIndex": "[if(equals(parameters('deploymentScenario'), 'healthcare'), 'care_policies_index', if(equals(parameters('deploymentScenario'), 'banking'), 'banking_policies_index', 'policies_index'))]",
             "catalogToolName": "[if(equals(parameters('deploymentScenario'), 'healthcare'), 'services_agent', if(equals(parameters('deploymentScenario'), 'banking'), 'accounts_agent', 'product_agent'))]",
             "policyToolName": "[if(equals(parameters('deploymentScenario'), 'healthcare'), 'care_policy_agent', if(equals(parameters('deploymentScenario'), 'banking'), 'banking_policy_agent', 'policy_agent'))]",
-            "reactAppLayoutConfig": "{\n  \"appConfig\": {\n      \"CHAT_CHATHISTORY\": {\n        \"CHAT\": 70,\n        \"CHATHISTORY\": 30\n      }\n    }\n  }\n}"
+            "reactAppLayoutConfig": "{\r\n  \"appConfig\": {\r\n      \"CHAT_CHATHISTORY\": {\r\n        \"CHAT\": 70,\r\n        \"CHATHISTORY\": 30\r\n      }\r\n    }\r\n  }\r\n}"
           },
           "resources": {
             "resourceGroupTags": {
@@ -5447,8 +5447,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.46.1.21595",
-                      "templateHash": "5005969515455354504"
+                      "version": "0.44.1.10279",
+                      "templateHash": "3232047823815133881"
                     }
                   },
                   "parameters": {
@@ -8749,8 +8749,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.46.1.21595",
-                      "templateHash": "1077806126224374403"
+                      "version": "0.44.1.10279",
+                      "templateHash": "5783288507350094145"
                     }
                   },
                   "parameters": {
@@ -9676,8 +9676,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.46.1.21595",
-                      "templateHash": "14375623146044395014"
+                      "version": "0.44.1.10279",
+                      "templateHash": "17026638034178729316"
                     }
                   },
                   "definitions": {
@@ -12542,8 +12542,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.46.1.21595",
-                      "templateHash": "4613446280405157854"
+                      "version": "0.44.1.10279",
+                      "templateHash": "13928883839220797481"
                     }
                   },
                   "parameters": {
@@ -14446,8 +14446,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.46.1.21595",
-                      "templateHash": "8420279536133240728"
+                      "version": "0.44.1.10279",
+                      "templateHash": "1680554660663753024"
                     }
                   },
                   "parameters": {
@@ -14986,8 +14986,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.46.1.21595",
-                      "templateHash": "14701803776432038764"
+                      "version": "0.44.1.10279",
+                      "templateHash": "10734514187033998183"
                     }
                   },
                   "parameters": {
@@ -16455,8 +16455,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.46.1.21595",
-                      "templateHash": "13006336383696924611"
+                      "version": "0.44.1.10279",
+                      "templateHash": "14627790702698637496"
                     }
                   },
                   "parameters": {
@@ -16964,8 +16964,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.46.1.21595",
-                      "templateHash": "17976113817590025731"
+                      "version": "0.44.1.10279",
+                      "templateHash": "11639188571768358148"
                     }
                   },
                   "parameters": {
@@ -26320,8 +26320,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.46.1.21595",
-                      "templateHash": "11076758087490966511"
+                      "version": "0.44.1.10279",
+                      "templateHash": "8816372137748980601"
                     }
                   },
                   "parameters": {
@@ -29828,8 +29828,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.46.1.21595",
-                      "templateHash": "45267059275214483"
+                      "version": "0.44.1.10279",
+                      "templateHash": "15866619731095149829"
                     }
                   },
                   "parameters": {
@@ -32628,8 +32628,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.46.1.21595",
-                      "templateHash": "14933983914799613850"
+                      "version": "0.44.1.10279",
+                      "templateHash": "943732916029725835"
                     }
                   },
                   "parameters": {
@@ -33344,9 +33344,9 @@
               },
               "dependsOn": [
                 "ai_foundry_project",
+                "[format('privateDnsZoneDeployments[{0}]', variables('dnsZoneIndex').cognitiveServices)]",
                 "[format('privateDnsZoneDeployments[{0}]', variables('dnsZoneIndex').aiServices)]",
                 "[format('privateDnsZoneDeployments[{0}]', variables('dnsZoneIndex').openAI)]",
-                "[format('privateDnsZoneDeployments[{0}]', variables('dnsZoneIndex').cognitiveServices)]",
                 "virtualNetwork"
               ]
             },
@@ -33376,8 +33376,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.46.1.21595",
-                      "templateHash": "14734711829211982487"
+                      "version": "0.44.1.10279",
+                      "templateHash": "5479596076171286810"
                     }
                   },
                   "parameters": {
@@ -33514,8 +33514,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.46.1.21595",
-                      "templateHash": "5315493943580072668"
+                      "version": "0.44.1.10279",
+                      "templateHash": "10180502016624897684"
                     }
                   },
                   "parameters": {
@@ -33682,8 +33682,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.46.1.21595",
-                      "templateHash": "16968649656855146631"
+                      "version": "0.44.1.10279",
+                      "templateHash": "371928985555429960"
                     }
                   },
                   "definitions": {
@@ -36371,8 +36371,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.46.1.21595",
-                      "templateHash": "716687752517927296"
+                      "version": "0.44.1.10279",
+                      "templateHash": "6391723411041592681"
                     }
                   },
                   "parameters": {
@@ -36566,8 +36566,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.46.1.21595",
-                      "templateHash": "17841877567317429172"
+                      "version": "0.44.1.10279",
+                      "templateHash": "709954433606367454"
                     }
                   },
                   "definitions": {
@@ -43117,8 +43117,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.46.1.21595",
-                      "templateHash": "1341821364014447993"
+                      "version": "0.44.1.10279",
+                      "templateHash": "13851921925562787404"
                     }
                   },
                   "definitions": {
@@ -47567,8 +47567,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.46.1.21595",
-                      "templateHash": "15442179113759093660"
+                      "version": "0.44.1.10279",
+                      "templateHash": "1571277744110287631"
                     }
                   },
                   "parameters": {
@@ -48468,9 +48468,7 @@
                   },
                   "diagnosticSettings": "[if(parameters('enableMonitoring'), createObject('value', createArray(createObject('workspaceResourceId', if(parameters('enableMonitoring'), if(variables('useExistingLogAnalytics'), extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', split(parameters('existingLogAnalyticsWorkspaceId'), '/')[2], split(parameters('existingLogAnalyticsWorkspaceId'), '/')[4]), 'Microsoft.OperationalInsights/workspaces', split(parameters('existingLogAnalyticsWorkspaceId'), '/')[8]), reference('log_analytics').outputs.resourceId.value), '')))), createObject('value', createArray()))]",
                   "applicationInsightResourceId": "[if(parameters('enableMonitoring'), createObject('value', reference('app_insights').outputs.resourceId.value), createObject('value', ''))]",
-                  "publicNetworkAccess": {
-                    "value": "Enabled"
-                  },
+                  "publicNetworkAccess": "[if(parameters('enablePrivateNetworking'), createObject('value', 'Disabled'), createObject('value', 'Enabled'))]",
                   "virtualNetworkSubnetId": "[if(parameters('enablePrivateNetworking'), createObject('value', reference('virtualNetwork').outputs.webserverfarmSubnetResourceId.value), createObject('value', ''))]",
                   "vnetRouteAllEnabled": {
                     "value": "[parameters('enablePrivateNetworking')]"
@@ -48481,6 +48479,7 @@
                   "acrUseManagedIdentityCreds": {
                     "value": true
                   },
+                  "privateEndpoints": "[if(parameters('enablePrivateNetworking'), createObject('value', createArray(createObject('name', format('pep-chat-api-{0}', variables('solutionSuffix')), 'customNetworkInterfaceName', format('nic-chat-api-{0}', variables('solutionSuffix')), 'privateDnsZoneGroup', createObject('privateDnsZoneGroupConfigs', createArray(createObject('privateDnsZoneResourceId', reference(format('privateDnsZoneDeployments[{0}]', variables('dnsZoneIndex').webApp)).outputs.resourceId.value))), 'service', 'sites', 'subnetResourceId', reference('virtualNetwork').outputs.backendSubnetResourceId.value))), createObject('value', createArray()))]",
                   "appSettings": {
                     "value": {
                       "AZURE_OPENAI_DEPLOYMENT_MODEL": "[parameters('gptModelName')]",
@@ -48544,8 +48543,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.46.1.21595",
-                      "templateHash": "11236004869715473159"
+                      "version": "0.44.1.10279",
+                      "templateHash": "2971165412380728978"
                     }
                   },
                   "definitions": {
@@ -64041,6 +64040,7 @@
                 "foundry_search_connection",
                 "hostingplan",
                 "log_analytics",
+                "[format('privateDnsZoneDeployments[{0}]', variables('dnsZoneIndex').webApp)]",
                 "virtualNetwork"
               ]
             },
@@ -64094,7 +64094,8 @@
                   "appSettings": {
                     "value": {
                       "NODE_ENV": "production",
-                      "VITE_API_BASE_URL": "[reference('chat_backend_app').outputs.appUrl.value]",
+                      "VITE_API_BASE_URL": "[if(parameters('enablePrivateNetworking'), '', reference('chat_backend_app').outputs.appUrl.value)]",
+                      "BACKEND_API_URL": "[if(parameters('enablePrivateNetworking'), reference('chat_backend_app').outputs.appUrl.value, '')]",
                       "DEPLOYMENT_SCENARIO": "[parameters('deploymentScenario')]",
                       "VITE_SCENARIO": "[parameters('deploymentScenario')]",
                       "CHAT_WELCOME_TITLE": "[variables('chatWelcomeTitle')]",
@@ -64110,8 +64111,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.46.1.21595",
-                      "templateHash": "11236004869715473159"
+                      "version": "0.44.1.10279",
+                      "templateHash": "2971165412380728978"
                     }
                   },
                   "definitions": {
@@ -79648,9 +79649,7 @@
                   },
                   "diagnosticSettings": "[if(parameters('enableMonitoring'), createObject('value', createArray(createObject('workspaceResourceId', if(parameters('enableMonitoring'), if(variables('useExistingLogAnalytics'), extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', split(parameters('existingLogAnalyticsWorkspaceId'), '/')[2], split(parameters('existingLogAnalyticsWorkspaceId'), '/')[4]), 'Microsoft.OperationalInsights/workspaces', split(parameters('existingLogAnalyticsWorkspaceId'), '/')[8]), reference('log_analytics').outputs.resourceId.value), '')))), createObject('value', createArray()))]",
                   "applicationInsightResourceId": "[if(parameters('enableMonitoring'), createObject('value', reference('app_insights').outputs.resourceId.value), createObject('value', ''))]",
-                  "publicNetworkAccess": {
-                    "value": "Enabled"
-                  },
+                  "publicNetworkAccess": "[if(parameters('enablePrivateNetworking'), createObject('value', 'Disabled'), createObject('value', 'Enabled'))]",
                   "virtualNetworkSubnetId": "[if(parameters('enablePrivateNetworking'), createObject('value', reference('virtualNetwork').outputs.webserverfarmSubnetResourceId.value), createObject('value', ''))]",
                   "vnetRouteAllEnabled": {
                     "value": "[parameters('enablePrivateNetworking')]"
@@ -79661,6 +79660,7 @@
                   "acrUseManagedIdentityCreds": {
                     "value": true
                   },
+                  "privateEndpoints": "[if(parameters('enablePrivateNetworking'), createObject('value', createArray(createObject('name', format('pep-scenario-api-{0}', variables('solutionSuffix')), 'customNetworkInterfaceName', format('nic-scenario-api-{0}', variables('solutionSuffix')), 'privateDnsZoneGroup', createObject('privateDnsZoneGroupConfigs', createArray(createObject('privateDnsZoneResourceId', reference(format('privateDnsZoneDeployments[{0}]', variables('dnsZoneIndex').webApp)).outputs.resourceId.value))), 'service', 'sites', 'subnetResourceId', reference('virtualNetwork').outputs.backendSubnetResourceId.value))), createObject('value', createArray()))]",
                   "appSettings": {
                     "value": {
                       "AZURE_OPENAI_DEPLOYMENT_MODEL": "[parameters('gptModelName')]",
@@ -79718,8 +79718,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.46.1.21595",
-                      "templateHash": "11236004869715473159"
+                      "version": "0.44.1.10279",
+                      "templateHash": "2971165412380728978"
                     }
                   },
                   "definitions": {
@@ -95215,6 +95215,7 @@
                 "foundry_search_connection",
                 "hostingplan",
                 "log_analytics",
+                "[format('privateDnsZoneDeployments[{0}]', variables('dnsZoneIndex').webApp)]",
                 "virtualNetwork"
               ]
             },
@@ -95270,8 +95271,9 @@
                   "appSettings": {
                     "value": {
                       "NODE_ENV": "production",
-                      "VITE_API_BASE_URL": "[reference('scenario_backend_app').outputs.appUrl.value]",
-                      "VITE_CHAT_API_BASE_URL": "[reference('chat_backend_app').outputs.appUrl.value]",
+                      "VITE_API_BASE_URL": "[if(parameters('enablePrivateNetworking'), '', reference('scenario_backend_app').outputs.appUrl.value)]",
+                      "BACKEND_API_URL": "[if(parameters('enablePrivateNetworking'), reference('scenario_backend_app').outputs.appUrl.value, '')]",
+                      "VITE_CHAT_API_BASE_URL": "[if(parameters('enablePrivateNetworking'), format('https://{0}.azurewebsites.net', variables('chatWebAppName')), reference('chat_backend_app').outputs.appUrl.value)]",
                       "DEPLOYMENT_SCENARIO": "[parameters('deploymentScenario')]",
                       "VITE_SCENARIO": "[parameters('deploymentScenario')]",
                       "VITE_HOST_APP_TITLE": "[variables('hostAppTitle')]",
@@ -95287,8 +95289,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.46.1.21595",
-                      "templateHash": "11236004869715473159"
+                      "version": "0.44.1.10279",
+                      "templateHash": "2971165412380728978"
                     }
                   },
                   "definitions": {
@@ -110830,8 +110832,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.46.1.21595",
-                      "templateHash": "14428393433289701976"
+                      "version": "0.44.1.10279",
+                      "templateHash": "6923046573019210252"
                     }
                   },
                   "parameters": {
@@ -111046,8 +111048,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.46.1.21595",
-                              "templateHash": "14185496479700676156"
+                              "version": "0.44.1.10279",
+                              "templateHash": "7322574716979180114"
                             }
                           },
                           "parameters": {
@@ -111168,8 +111170,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.46.1.21595",
-                              "templateHash": "14185496479700676156"
+                              "version": "0.44.1.10279",
+                              "templateHash": "7322574716979180114"
                             }
                           },
                           "parameters": {

--- a/infra/main.json
+++ b/infra/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.44.1.10279",
-      "templateHash": "6515409251207683035"
+      "version": "0.46.1.21595",
+      "templateHash": "9112382489412998006"
     }
   },
   "parameters": {
@@ -387,8 +387,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.44.1.10279",
-              "templateHash": "9212219831260544815"
+              "version": "0.46.1.21595",
+              "templateHash": "9629672312866105058"
             }
           },
           "parameters": {
@@ -671,7 +671,7 @@
             "policiesSearchIndex": "[if(equals(parameters('deploymentScenario'), 'healthcare'), 'care_policies_index', if(equals(parameters('deploymentScenario'), 'banking'), 'banking_policies_index', 'policies_index'))]",
             "catalogToolName": "[if(equals(parameters('deploymentScenario'), 'healthcare'), 'services_agent', if(equals(parameters('deploymentScenario'), 'banking'), 'accounts_agent', 'product_agent'))]",
             "policyToolName": "[if(equals(parameters('deploymentScenario'), 'healthcare'), 'care_policy_agent', if(equals(parameters('deploymentScenario'), 'banking'), 'banking_policy_agent', 'policy_agent'))]",
-            "reactAppLayoutConfig": "{\r\n  \"appConfig\": {\r\n      \"CHAT_CHATHISTORY\": {\r\n        \"CHAT\": 70,\r\n        \"CHATHISTORY\": 30\r\n      }\r\n    }\r\n  }\r\n}"
+            "reactAppLayoutConfig": "{\n  \"appConfig\": {\n      \"CHAT_CHATHISTORY\": {\n        \"CHAT\": 70,\n        \"CHATHISTORY\": 30\n      }\n    }\n  }\n}"
           },
           "resources": [
             {
@@ -707,8 +707,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.44.1.10279",
-                      "templateHash": "18362209914173142473"
+                      "version": "0.46.1.21595",
+                      "templateHash": "3561501102733674034"
                     }
                   },
                   "parameters": {
@@ -837,8 +837,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.44.1.10279",
-                      "templateHash": "3199910078817503702"
+                      "version": "0.46.1.21595",
+                      "templateHash": "2461614014827306322"
                     }
                   },
                   "parameters": {
@@ -997,8 +997,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.44.1.10279",
-                      "templateHash": "9172330732311277268"
+                      "version": "0.46.1.21595",
+                      "templateHash": "10528706051101679884"
                     }
                   },
                   "parameters": {
@@ -1222,8 +1222,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.44.1.10279",
-                      "templateHash": "4978423908175488703"
+                      "version": "0.46.1.21595",
+                      "templateHash": "10331016231175084282"
                     }
                   },
                   "parameters": {
@@ -1360,8 +1360,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.44.1.10279",
-                      "templateHash": "10180502016624897684"
+                      "version": "0.46.1.21595",
+                      "templateHash": "5315493943580072668"
                     }
                   },
                   "parameters": {
@@ -1498,8 +1498,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.44.1.10279",
-                      "templateHash": "13476994621581605010"
+                      "version": "0.46.1.21595",
+                      "templateHash": "5701731356162862350"
                     }
                   },
                   "parameters": {
@@ -1687,8 +1687,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.44.1.10279",
-                              "templateHash": "2357632753579583529"
+                              "version": "0.46.1.21595",
+                              "templateHash": "11160875200628826596"
                             }
                           },
                           "parameters": {
@@ -1902,8 +1902,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.44.1.10279",
-                      "templateHash": "6391723411041592681"
+                      "version": "0.46.1.21595",
+                      "templateHash": "716687752517927296"
                     }
                   },
                   "parameters": {
@@ -2085,8 +2085,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.44.1.10279",
-                      "templateHash": "17334509417641963470"
+                      "version": "0.46.1.21595",
+                      "templateHash": "16930840148567813821"
                     }
                   },
                   "parameters": {
@@ -2299,8 +2299,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.44.1.10279",
-                      "templateHash": "6730962297935458636"
+                      "version": "0.46.1.21595",
+                      "templateHash": "14293411736980892825"
                     }
                   },
                   "parameters": {
@@ -2469,8 +2469,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.44.1.10279",
-                      "templateHash": "8496143357348681814"
+                      "version": "0.46.1.21595",
+                      "templateHash": "17503458259299065073"
                     }
                   },
                   "parameters": {
@@ -2703,8 +2703,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.44.1.10279",
-                      "templateHash": "15104078240780944367"
+                      "version": "0.46.1.21595",
+                      "templateHash": "15416323965013625336"
                     }
                   },
                   "parameters": {
@@ -3011,8 +3011,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.44.1.10279",
-                      "templateHash": "15104078240780944367"
+                      "version": "0.46.1.21595",
+                      "templateHash": "15416323965013625336"
                     }
                   },
                   "parameters": {
@@ -3359,8 +3359,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.44.1.10279",
-                      "templateHash": "15104078240780944367"
+                      "version": "0.46.1.21595",
+                      "templateHash": "15416323965013625336"
                     }
                   },
                   "parameters": {
@@ -3668,8 +3668,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.44.1.10279",
-                      "templateHash": "15104078240780944367"
+                      "version": "0.46.1.21595",
+                      "templateHash": "15416323965013625336"
                     }
                   },
                   "parameters": {
@@ -3978,8 +3978,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.44.1.10279",
-                      "templateHash": "9397001796125384955"
+                      "version": "0.46.1.21595",
+                      "templateHash": "15322885636837012121"
                     }
                   },
                   "parameters": {
@@ -4321,8 +4321,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.44.1.10279",
-                              "templateHash": "15240584362831878613"
+                              "version": "0.46.1.21595",
+                              "templateHash": "1001648557732946394"
                             }
                           },
                           "parameters": {
@@ -4443,8 +4443,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.44.1.10279",
-                              "templateHash": "15240584362831878613"
+                              "version": "0.46.1.21595",
+                              "templateHash": "1001648557732946394"
                             }
                           },
                           "parameters": {
@@ -5007,8 +5007,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.44.1.10279",
-              "templateHash": "7642203634815326815"
+              "version": "0.46.1.21595",
+              "templateHash": "1121657690312561341"
             }
           },
           "parameters": {
@@ -5385,7 +5385,7 @@
             "policiesSearchIndex": "[if(equals(parameters('deploymentScenario'), 'healthcare'), 'care_policies_index', if(equals(parameters('deploymentScenario'), 'banking'), 'banking_policies_index', 'policies_index'))]",
             "catalogToolName": "[if(equals(parameters('deploymentScenario'), 'healthcare'), 'services_agent', if(equals(parameters('deploymentScenario'), 'banking'), 'accounts_agent', 'product_agent'))]",
             "policyToolName": "[if(equals(parameters('deploymentScenario'), 'healthcare'), 'care_policy_agent', if(equals(parameters('deploymentScenario'), 'banking'), 'banking_policy_agent', 'policy_agent'))]",
-            "reactAppLayoutConfig": "{\r\n  \"appConfig\": {\r\n      \"CHAT_CHATHISTORY\": {\r\n        \"CHAT\": 70,\r\n        \"CHATHISTORY\": 30\r\n      }\r\n    }\r\n  }\r\n}"
+            "reactAppLayoutConfig": "{\n  \"appConfig\": {\n      \"CHAT_CHATHISTORY\": {\n        \"CHAT\": 70,\n        \"CHATHISTORY\": 30\n      }\n    }\n  }\n}"
           },
           "resources": {
             "resourceGroupTags": {
@@ -5447,8 +5447,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.44.1.10279",
-                      "templateHash": "3232047823815133881"
+                      "version": "0.46.1.21595",
+                      "templateHash": "5005969515455354504"
                     }
                   },
                   "parameters": {
@@ -8749,8 +8749,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.44.1.10279",
-                      "templateHash": "5783288507350094145"
+                      "version": "0.46.1.21595",
+                      "templateHash": "1077806126224374403"
                     }
                   },
                   "parameters": {
@@ -9676,8 +9676,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.44.1.10279",
-                      "templateHash": "17026638034178729316"
+                      "version": "0.46.1.21595",
+                      "templateHash": "14375623146044395014"
                     }
                   },
                   "definitions": {
@@ -12542,8 +12542,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.44.1.10279",
-                      "templateHash": "13928883839220797481"
+                      "version": "0.46.1.21595",
+                      "templateHash": "4613446280405157854"
                     }
                   },
                   "parameters": {
@@ -14446,8 +14446,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.44.1.10279",
-                      "templateHash": "1680554660663753024"
+                      "version": "0.46.1.21595",
+                      "templateHash": "8420279536133240728"
                     }
                   },
                   "parameters": {
@@ -14986,8 +14986,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.44.1.10279",
-                      "templateHash": "10734514187033998183"
+                      "version": "0.46.1.21595",
+                      "templateHash": "14701803776432038764"
                     }
                   },
                   "parameters": {
@@ -16455,8 +16455,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.44.1.10279",
-                      "templateHash": "14627790702698637496"
+                      "version": "0.46.1.21595",
+                      "templateHash": "13006336383696924611"
                     }
                   },
                   "parameters": {
@@ -16964,8 +16964,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.44.1.10279",
-                      "templateHash": "11639188571768358148"
+                      "version": "0.46.1.21595",
+                      "templateHash": "17976113817590025731"
                     }
                   },
                   "parameters": {
@@ -26320,8 +26320,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.44.1.10279",
-                      "templateHash": "8816372137748980601"
+                      "version": "0.46.1.21595",
+                      "templateHash": "11076758087490966511"
                     }
                   },
                   "parameters": {
@@ -29828,8 +29828,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.44.1.10279",
-                      "templateHash": "15866619731095149829"
+                      "version": "0.46.1.21595",
+                      "templateHash": "45267059275214483"
                     }
                   },
                   "parameters": {
@@ -32628,8 +32628,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.44.1.10279",
-                      "templateHash": "943732916029725835"
+                      "version": "0.46.1.21595",
+                      "templateHash": "14933983914799613850"
                     }
                   },
                   "parameters": {
@@ -33344,9 +33344,9 @@
               },
               "dependsOn": [
                 "ai_foundry_project",
+                "[format('privateDnsZoneDeployments[{0}]', variables('dnsZoneIndex').openAI)]",
                 "[format('privateDnsZoneDeployments[{0}]', variables('dnsZoneIndex').cognitiveServices)]",
                 "[format('privateDnsZoneDeployments[{0}]', variables('dnsZoneIndex').aiServices)]",
-                "[format('privateDnsZoneDeployments[{0}]', variables('dnsZoneIndex').openAI)]",
                 "virtualNetwork"
               ]
             },
@@ -33376,8 +33376,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.44.1.10279",
-                      "templateHash": "5479596076171286810"
+                      "version": "0.46.1.21595",
+                      "templateHash": "14734711829211982487"
                     }
                   },
                   "parameters": {
@@ -33514,8 +33514,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.44.1.10279",
-                      "templateHash": "10180502016624897684"
+                      "version": "0.46.1.21595",
+                      "templateHash": "5315493943580072668"
                     }
                   },
                   "parameters": {
@@ -33682,8 +33682,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.44.1.10279",
-                      "templateHash": "371928985555429960"
+                      "version": "0.46.1.21595",
+                      "templateHash": "16968649656855146631"
                     }
                   },
                   "definitions": {
@@ -36371,8 +36371,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.44.1.10279",
-                      "templateHash": "6391723411041592681"
+                      "version": "0.46.1.21595",
+                      "templateHash": "716687752517927296"
                     }
                   },
                   "parameters": {
@@ -36566,8 +36566,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.44.1.10279",
-                      "templateHash": "709954433606367454"
+                      "version": "0.46.1.21595",
+                      "templateHash": "17841877567317429172"
                     }
                   },
                   "definitions": {
@@ -43117,8 +43117,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.44.1.10279",
-                      "templateHash": "13851921925562787404"
+                      "version": "0.46.1.21595",
+                      "templateHash": "1341821364014447993"
                     }
                   },
                   "definitions": {
@@ -47567,8 +47567,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.44.1.10279",
-                      "templateHash": "1571277744110287631"
+                      "version": "0.46.1.21595",
+                      "templateHash": "15442179113759093660"
                     }
                   },
                   "parameters": {
@@ -48543,8 +48543,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.44.1.10279",
-                      "templateHash": "2971165412380728978"
+                      "version": "0.46.1.21595",
+                      "templateHash": "11236004869715473159"
                     }
                   },
                   "definitions": {
@@ -64111,8 +64111,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.44.1.10279",
-                      "templateHash": "2971165412380728978"
+                      "version": "0.46.1.21595",
+                      "templateHash": "11236004869715473159"
                     }
                   },
                   "definitions": {
@@ -79718,8 +79718,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.44.1.10279",
-                      "templateHash": "2971165412380728978"
+                      "version": "0.46.1.21595",
+                      "templateHash": "11236004869715473159"
                     }
                   },
                   "definitions": {
@@ -95289,8 +95289,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.44.1.10279",
-                      "templateHash": "2971165412380728978"
+                      "version": "0.46.1.21595",
+                      "templateHash": "11236004869715473159"
                     }
                   },
                   "definitions": {
@@ -110832,8 +110832,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.44.1.10279",
-                      "templateHash": "6923046573019210252"
+                      "version": "0.46.1.21595",
+                      "templateHash": "14428393433289701976"
                     }
                   },
                   "parameters": {
@@ -111048,8 +111048,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.44.1.10279",
-                              "templateHash": "7322574716979180114"
+                              "version": "0.46.1.21595",
+                              "templateHash": "14185496479700676156"
                             }
                           },
                           "parameters": {
@@ -111170,8 +111170,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.44.1.10279",
-                              "templateHash": "7322574716979180114"
+                              "version": "0.46.1.21595",
+                              "templateHash": "14185496479700676156"
                             }
                           },
                           "parameters": {

--- a/scenario-app/frontend/Dockerfile
+++ b/scenario-app/frontend/Dockerfile
@@ -18,6 +18,10 @@ COPY --from=widget-builder /src/chat-app/frontend/dist/widget.js ./dist/widget.j
 FROM mcr.microsoft.com/azurelinux/base/nginx:1.28.3-8-azl3.0.20260722
 COPY --from=app-builder /src/scenario-app/frontend/dist /usr/share/nginx/html
 COPY scenario-app/frontend/nginx.conf /etc/nginx/nginx.conf
+
+# Create empty api-proxy conf (overwritten at startup for WAF/private deployments)
+RUN mkdir -p /etc/nginx/conf.d && touch /etc/nginx/conf.d/api-proxy.conf
+
 COPY scenario-app/frontend/startup.sh /docker-entrypoint.d/startup.sh
 RUN chmod +x /docker-entrypoint.d/startup.sh
 RUN sed -i 's/\r$//' /docker-entrypoint.d/startup.sh

--- a/scenario-app/frontend/nginx.conf
+++ b/scenario-app/frontend/nginx.conf
@@ -12,6 +12,9 @@ http {
         root /usr/share/nginx/html;
         index index.html;
 
+        # Include API proxy config (generated at startup for WAF/private networking deployments)
+        include /etc/nginx/conf.d/api-proxy.conf;
+
         # Handle React Router
         location / {
             try_files $uri $uri/ /index.html;

--- a/scenario-app/frontend/startup.sh
+++ b/scenario-app/frontend/startup.sh
@@ -1,5 +1,11 @@
 #!/bin/sh
 
+# Escape a value for safe inclusion inside a single-quoted JS string literal
+# (handles backslashes and single quotes, e.g. a title like "Bob's Shop").
+js_escape() {
+  printf '%s' "$1" | sed "s/\\\\/\\\\\\\\/g; s/'/\\\\'/g"
+}
+
 if [ -z "$VITE_SCENARIO" ]; then
   VITE_SCENARIO="${DEPLOYMENT_SCENARIO:-ecommerce}"
 fi
@@ -13,10 +19,10 @@ if [ -n "${BACKEND_API_URL}" ]; then
 cat > /usr/share/nginx/html/runtime-config.js << EOF
 window.__RUNTIME_CONFIG__ = {
   VITE_API_BASE_URL: window.location.origin,
-  VITE_CHAT_API_BASE_URL: '${VITE_CHAT_API_BASE_URL}',
-  VITE_CHAT_WIDGET_THEME: '${VITE_CHAT_WIDGET_THEME}',
-  VITE_SCENARIO: '${VITE_SCENARIO}',
-  VITE_HOST_APP_TITLE: '${VITE_HOST_APP_TITLE}'
+  VITE_CHAT_API_BASE_URL: '$(js_escape "${VITE_CHAT_API_BASE_URL}")',
+  VITE_CHAT_WIDGET_THEME: '$(js_escape "${VITE_CHAT_WIDGET_THEME}")',
+  VITE_SCENARIO: '$(js_escape "${VITE_SCENARIO}")',
+  VITE_HOST_APP_TITLE: '$(js_escape "${VITE_HOST_APP_TITLE}")'
 };
 EOF
 else
@@ -42,11 +48,11 @@ else
 
 cat > /usr/share/nginx/html/runtime-config.js << EOF
 window.__RUNTIME_CONFIG__ = {
-  VITE_API_BASE_URL: '${VITE_API_BASE_URL}',
-  VITE_CHAT_API_BASE_URL: '${VITE_CHAT_API_BASE_URL}',
-  VITE_CHAT_WIDGET_THEME: '${VITE_CHAT_WIDGET_THEME}',
-  VITE_SCENARIO: '${VITE_SCENARIO}',
-  VITE_HOST_APP_TITLE: '${VITE_HOST_APP_TITLE}'
+  VITE_API_BASE_URL: '$(js_escape "${VITE_API_BASE_URL}")',
+  VITE_CHAT_API_BASE_URL: '$(js_escape "${VITE_CHAT_API_BASE_URL}")',
+  VITE_CHAT_WIDGET_THEME: '$(js_escape "${VITE_CHAT_WIDGET_THEME}")',
+  VITE_SCENARIO: '$(js_escape "${VITE_SCENARIO}")',
+  VITE_HOST_APP_TITLE: '$(js_escape "${VITE_HOST_APP_TITLE}")'
 };
 EOF
 fi
@@ -55,14 +61,16 @@ fi
 # When BACKEND_API_URL is set the scenario backend API is private and this
 # frontend's nginx proxies /api/ requests to it over the VNet.
 if [ -n "${BACKEND_API_URL}" ]; then
-  BACKEND_HOST=$(echo "${BACKEND_API_URL}" | sed 's|https://||; s|http://||; s|/.*||')
+  # Strip any trailing slash so proxy_pass + the /api/ location prefix don't produce a malformed path.
+  BACKEND_API_URL="${BACKEND_API_URL%/}"
+  BACKEND_HOST=$(printf '%s' "${BACKEND_API_URL}" | sed 's|https\?://||; s|/.*||')
   cat > /etc/nginx/conf.d/api-proxy.conf << PROXYEOF
 # Reverse proxy for backend API - WAF private networking deployment
 location /api/ {
     resolver 168.63.129.16 valid=30s;
     set \$backend "${BACKEND_API_URL}";
     proxy_pass \$backend;
-    proxy_set_header Host ${BACKEND_HOST};
+    proxy_set_header Host "${BACKEND_HOST}";
     proxy_set_header X-Real-IP \$remote_addr;
     proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto \$scheme;

--- a/scenario-app/frontend/startup.sh
+++ b/scenario-app/frontend/startup.sh
@@ -1,28 +1,44 @@
 #!/bin/sh
 
-if [ -z "$VITE_API_BASE_URL" ]; then
-  host="${WEBSITE_HOSTNAME:-}"
-  case "$host" in
-    app-scenario-*.*)
-      suf="${host#app-scenario-}"
-      VITE_API_BASE_URL="https://api-scenario-${suf}"
-      ;;
-  esac
-fi
-
-if [ -z "$VITE_CHAT_API_BASE_URL" ]; then
-  host="${WEBSITE_HOSTNAME:-}"
-  case "$host" in
-    app-scenario-*.*)
-      suf="${host#app-scenario-}"
-      VITE_CHAT_API_BASE_URL="https://api-chat-${suf}"
-      ;;
-  esac
-fi
-
 if [ -z "$VITE_SCENARIO" ]; then
   VITE_SCENARIO="${DEPLOYMENT_SCENARIO:-ecommerce}"
 fi
+
+# WAF/private networking deployment: BACKEND_API_URL is set when the scenario
+# backend API is private. The SPA then calls its own origin (nginx reverse-proxies
+# /api/ to the private scenario backend over the VNet). The embedded chat widget
+# points at the public chat frontend (VITE_CHAT_API_BASE_URL), which in turn
+# proxies to the private chat backend.
+if [ -n "${BACKEND_API_URL}" ]; then
+cat > /usr/share/nginx/html/runtime-config.js << EOF
+window.__RUNTIME_CONFIG__ = {
+  VITE_API_BASE_URL: window.location.origin,
+  VITE_CHAT_API_BASE_URL: '${VITE_CHAT_API_BASE_URL}',
+  VITE_CHAT_WIDGET_THEME: '${VITE_CHAT_WIDGET_THEME}',
+  VITE_SCENARIO: '${VITE_SCENARIO}',
+  VITE_HOST_APP_TITLE: '${VITE_HOST_APP_TITLE}'
+};
+EOF
+else
+  if [ -z "$VITE_API_BASE_URL" ]; then
+    host="${WEBSITE_HOSTNAME:-}"
+    case "$host" in
+      app-scenario-*.*)
+        suf="${host#app-scenario-}"
+        VITE_API_BASE_URL="https://api-scenario-${suf}"
+        ;;
+    esac
+  fi
+
+  if [ -z "$VITE_CHAT_API_BASE_URL" ]; then
+    host="${WEBSITE_HOSTNAME:-}"
+    case "$host" in
+      app-scenario-*.*)
+        suf="${host#app-scenario-}"
+        VITE_CHAT_API_BASE_URL="https://api-chat-${suf}"
+        ;;
+    esac
+  fi
 
 cat > /usr/share/nginx/html/runtime-config.js << EOF
 window.__RUNTIME_CONFIG__ = {
@@ -33,5 +49,37 @@ window.__RUNTIME_CONFIG__ = {
   VITE_HOST_APP_TITLE: '${VITE_HOST_APP_TITLE}'
 };
 EOF
+fi
 
-nginx -g "daemon off;"
+# Generate the API reverse proxy config for WAF/private networking deployments.
+# When BACKEND_API_URL is set the scenario backend API is private and this
+# frontend's nginx proxies /api/ requests to it over the VNet.
+if [ -n "${BACKEND_API_URL}" ]; then
+  BACKEND_HOST=$(echo "${BACKEND_API_URL}" | sed 's|https://||; s|http://||; s|/.*||')
+  cat > /etc/nginx/conf.d/api-proxy.conf << PROXYEOF
+# Reverse proxy for backend API - WAF private networking deployment
+location /api/ {
+    resolver 168.63.129.16 valid=30s;
+    set \$backend "${BACKEND_API_URL}";
+    proxy_pass \$backend;
+    proxy_set_header Host ${BACKEND_HOST};
+    proxy_set_header X-Real-IP \$remote_addr;
+    proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto \$scheme;
+    proxy_ssl_server_name on;
+    proxy_read_timeout 300s;
+    proxy_connect_timeout 60s;
+    proxy_buffering off;
+
+    # WebSocket support (needed for /api/voice/ws/... connections)
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade \$http_upgrade;
+    proxy_set_header Connection "upgrade";
+}
+PROXYEOF
+else
+  # Empty file for non-WAF deployments (ensures the nginx include does not error)
+  > /etc/nginx/conf.d/api-proxy.conf
+fi
+
+exec nginx -g "daemon off;"


### PR DESCRIPTION
## Purpose
This pull request introduces enhancements to support secure deployments with Azure WAF/private networking, focusing on dynamic backend API proxying and improved infrastructure configuration. The main changes ensure that when private networking is enabled, the frontend securely communicates with the backend via an NGINX reverse proxy, and the infrastructure templates properly configure private endpoints and environment variables.

**Frontend and NGINX enhancements for private networking:**

* The `startup.sh` script now detects when `BACKEND_API_URL` is set (private networking scenario) and generates both a runtime config and an NGINX reverse proxy configuration to forward `/api/` requests to the backend over the VNet, including WebSocket support. [[1]](diffhunk://#diff-b110a24358c46beaacc9c191bbcdfb2f9907d34d05137400f7699d9dbb4b3f89R3-R12) [[2]](diffhunk://#diff-b110a24358c46beaacc9c191bbcdfb2f9907d34d05137400f7699d9dbb4b3f89R28-R61)
* The `nginx.conf` file is updated to include the generated API proxy config, ensuring seamless integration for both public and private deployments.
* The Dockerfile ensures the proxy config file exists and is writable at startup, preventing NGINX errors on first run.

**Infrastructure as Code (Bicep/ARM) updates:**

* The Bicep templates now enable or disable public network access and configure private endpoints for backend services based on the `enablePrivateNetworking` flag, automating secure deployment scenarios. [[1]](diffhunk://#diff-0c8d399dfddf2946045933947879b1e60a1fc5942a4e38e50a35f7ef28406bbfL839-R858) [[2]](diffhunk://#diff-0c8d399dfddf2946045933947879b1e60a1fc5942a4e38e50a35f7ef28406bbfL961-R980)
* Application settings for frontend deployments are set so that `VITE_API_BASE_URL` is blank and `BACKEND_API_URL` points to the backend only when private networking is enabled, ensuring the frontend uses the correct proxying behavior. [[1]](diffhunk://#diff-0c8d399dfddf2946045933947879b1e60a1fc5942a4e38e50a35f7ef28406bbfL934-R935) [[2]](diffhunk://#diff-0c8d399dfddf2946045933947879b1e60a1fc5942a4e38e50a35f7ef28406bbfL1052-R1054)

**Other changes:**

* The ARM template JSON reflects the new Bicep logic and generator version, and corrects some resource dependency ordering. [[1]](diffhunk://#diff-ac703cdc1a63d20f6804d2a91efeb5c8754cd680722682d53ada361533db450fL8-R9) [[2]](diffhunk://#diff-ac703cdc1a63d20f6804d2a91efeb5c8754cd680722682d53ada361533db450fL28346-R28347)

These changes together allow the application to be deployed securely in environments with private networking, with the frontend automatically proxying API traffic to the backend as needed.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->